### PR TITLE
Feat/gui implement parsing for pbc pic pie and smg commands zappy gui

### DIFF
--- a/gui/include/Parsing/ServerParser.hpp
+++ b/gui/include/Parsing/ServerParser.hpp
@@ -54,7 +54,7 @@ class Gui::ServerParser {
             INT,
             STRING,
             MESSAGE,
-            TEAMS
+            LIST_INT
         };
 
     private:
@@ -74,7 +74,7 @@ class Gui::ServerParser {
             {"pin", std::vector<ParseType>{INT, INT, INT, INT, INT, INT, INT, INT, INT, INT}},
             {"pex", std::vector<ParseType>{INT}},
             {"pbc", std::vector<ParseType>{INT, MESSAGE}},
-            //pic
+            {"pic", std::vector<ParseType>{INT, INT, INT, LIST_INT}},
             {"pie", std::vector<ParseType>{INT, INT, INT}},
             {"pfk", std::vector<ParseType>{INT}},
             {"pdr", std::vector<ParseType>{INT, INT}},
@@ -127,4 +127,14 @@ class Gui::ServerParser {
          * @return std::vector<std::string> - arguments parsed
          */
         std::vector<std::string> parseMessage(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName);
+
+        /**
+         * @brief Parse a list of int in the command stream.
+         *
+         * @param stream Stream to parse.
+         * @param arguments List of arguments parsed.
+         * @param commandName Name of the server command.
+         * @return std::vector<std::string> - arguments parsed
+         */
+        std::vector<std::string> parseListInt(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName);
 };

--- a/gui/include/Parsing/ServerParser.hpp
+++ b/gui/include/Parsing/ServerParser.hpp
@@ -52,8 +52,7 @@ class Gui::ServerParser {
          */
         enum ParseType {
             INT,
-            STRING,
-            HASHTAG
+            STRING
         };
 
     private:
@@ -67,21 +66,21 @@ class Gui::ServerParser {
             {"msz", std::vector<ParseType>{INT, INT}},
             {"bct", std::vector<ParseType>{INT, INT, INT, INT, INT, INT, INT, INT, INT}},
             {"tna", std::vector<ParseType>{STRING}},
-            {"pnw", std::vector<ParseType>{HASHTAG, INT, INT, INT, INT, STRING}},
-            {"ppo", std::vector<ParseType>{HASHTAG, INT, INT, INT}},
-            {"plv", std::vector<ParseType>{HASHTAG, INT}},
-            {"pin", std::vector<ParseType>{HASHTAG, INT, INT, INT, INT, INT, INT, INT, INT, INT}},
-            {"pex", std::vector<ParseType>{HASHTAG}},
+            {"pnw", std::vector<ParseType>{INT, INT, INT, INT, INT, STRING}},
+            {"ppo", std::vector<ParseType>{INT, INT, INT, INT}},
+            {"plv", std::vector<ParseType>{INT, INT}},
+            {"pin", std::vector<ParseType>{INT, INT, INT, INT, INT, INT, INT, INT, INT, INT}},
+            {"pex", std::vector<ParseType>{INT}},
             //pbc
             //pic
             {"pie", std::vector<ParseType>{INT, INT, INT}},
-            {"pfk", std::vector<ParseType>{HASHTAG}},
-            {"pdr", std::vector<ParseType>{HASHTAG, INT}},
-            {"pgt", std::vector<ParseType>{HASHTAG, INT}},
-            {"pdi", std::vector<ParseType>{HASHTAG}},
-            {"enw", std::vector<ParseType>{HASHTAG, HASHTAG, INT, INT}},
-            {"ebo", std::vector<ParseType>{HASHTAG}},
-            {"edi", std::vector<ParseType>{HASHTAG}},
+            {"pfk", std::vector<ParseType>{INT}},
+            {"pdr", std::vector<ParseType>{INT, INT}},
+            {"pgt", std::vector<ParseType>{INT, INT}},
+            {"pdi", std::vector<ParseType>{INT}},
+            {"enw", std::vector<ParseType>{INT, INT, INT, INT}},
+            {"ebo", std::vector<ParseType>{INT}},
+            {"edi", std::vector<ParseType>{INT}},
             {"sgt", std::vector<ParseType>{INT}},
             {"sst", std::vector<ParseType>{INT}},
             {"seg", std::vector<ParseType>{STRING}},
@@ -116,13 +115,4 @@ class Gui::ServerParser {
          * @return std::vector<std::string> - arguments parsed
          */
         std::vector<std::string> parseString(std::istringstream& stream, std::vector<std::string> arguments);
-
-        /**
-         * @brief Parse an hashtag in the command stream.
-         *
-         * @param stream Stream to parse.
-         * @param arguments List of arguments parsed.
-         * @return std::vector<std::string> - arguments parsed
-         */
-        std::vector<std::string> parseHashtag(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName);
 };

--- a/gui/include/Parsing/ServerParser.hpp
+++ b/gui/include/Parsing/ServerParser.hpp
@@ -86,7 +86,7 @@ class Gui::ServerParser {
             {"sgt", std::vector<ParseType>{INT}},
             {"sst", std::vector<ParseType>{INT}},
             {"seg", std::vector<ParseType>{STRING}},
-            //smg
+            {"smg", std::vector<ParseType>{MESSAGE}},
             {"suc", std::vector<ParseType>{}},
             {"sbp", std::vector<ParseType>{}}
         };

--- a/gui/include/Parsing/ServerParser.hpp
+++ b/gui/include/Parsing/ServerParser.hpp
@@ -52,7 +52,9 @@ class Gui::ServerParser {
          */
         enum ParseType {
             INT,
-            STRING
+            STRING,
+            MESSAGE,
+            TEAMS
         };
 
     private:
@@ -71,7 +73,7 @@ class Gui::ServerParser {
             {"plv", std::vector<ParseType>{INT, INT}},
             {"pin", std::vector<ParseType>{INT, INT, INT, INT, INT, INT, INT, INT, INT, INT}},
             {"pex", std::vector<ParseType>{INT}},
-            //pbc
+            {"pbc", std::vector<ParseType>{INT, MESSAGE}},
             //pic
             {"pie", std::vector<ParseType>{INT, INT, INT}},
             {"pfk", std::vector<ParseType>{INT}},
@@ -115,4 +117,14 @@ class Gui::ServerParser {
          * @return std::vector<std::string> - arguments parsed
          */
         std::vector<std::string> parseString(std::istringstream& stream, std::vector<std::string> arguments);
+
+        /**
+         * @brief Parse a message in the command stream.
+         *
+         * @param stream Stream to parse.
+         * @param arguments List of arguments parsed.
+         * @param commandName Name of the server command.
+         * @return std::vector<std::string> - arguments parsed
+         */
+        std::vector<std::string> parseMessage(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName);
 };

--- a/gui/include/Parsing/ServerParser.hpp
+++ b/gui/include/Parsing/ServerParser.hpp
@@ -72,6 +72,9 @@ class Gui::ServerParser {
             {"plv", std::vector<ParseType>{HASHTAG, INT}},
             {"pin", std::vector<ParseType>{HASHTAG, INT, INT, INT, INT, INT, INT, INT, INT, INT}},
             {"pex", std::vector<ParseType>{HASHTAG}},
+            //pbc
+            //pic
+            {"pie", std::vector<ParseType>{INT, INT, INT}},
             {"pfk", std::vector<ParseType>{HASHTAG}},
             {"pdr", std::vector<ParseType>{HASHTAG, INT}},
             {"pgt", std::vector<ParseType>{HASHTAG, INT}},
@@ -82,10 +85,9 @@ class Gui::ServerParser {
             {"sgt", std::vector<ParseType>{INT}},
             {"sst", std::vector<ParseType>{INT}},
             {"seg", std::vector<ParseType>{STRING}},
+            //smg
             {"suc", std::vector<ParseType>{}},
             {"sbp", std::vector<ParseType>{}}
-            // TODO : pbc, pic, pie, smg
-            // #15 (https://github.com/FppEpitech/Zappy/issues/15))
         };
 
         /**

--- a/gui/src/Parsing/ParseCommandLine.cpp
+++ b/gui/src/Parsing/ParseCommandLine.cpp
@@ -38,10 +38,8 @@ void Gui::ParseCommandLine::parseFlags(int argc, char **argv)
         } else
             throw Errors::ParseCommandLineException(GUI_USAGE);
     }
-    if (!isPort || !isHostname) {
-        std::cout << isPort << isHostname << std::endl;
+    if (!isPort || !isHostname)
         throw Errors::ParseCommandLineException(GUI_USAGE);
-    }
 }
 
 int Gui::ParseCommandLine::getPort(void)

--- a/gui/src/Parsing/ServerParser.cpp
+++ b/gui/src/Parsing/ServerParser.cpp
@@ -42,11 +42,6 @@ std::vector<std::string> Gui::ServerParser::parseCommand(const std::string& comm
                 arguments = parseString(stream, arguments);
                 break;
             }
-            case Gui::ServerParser::ParseType::HASHTAG:
-            {
-                arguments = parseHashtag(stream, arguments, commandName);
-                break;
-            }
             default:
                 break;
         }
@@ -72,17 +67,5 @@ std::vector<std::string> Gui::ServerParser::parseString(std::istringstream& stre
     std::string str;
     stream >> str;
     arguments.push_back(str);
-    return arguments;
-}
-
-std::vector<std::string> Gui::ServerParser::parseHashtag(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName)
-{
-    char hashtag;
-    stream >> hashtag;
-    if (hashtag != '#')
-        throw Errors::ServerParserException("Wrong parameters for '" + commandName + "' command.");
-    int nb;
-    stream >> nb;
-    arguments.push_back(std::to_string(nb));
     return arguments;
 }

--- a/gui/src/Parsing/ServerParser.cpp
+++ b/gui/src/Parsing/ServerParser.cpp
@@ -47,6 +47,11 @@ std::vector<std::string> Gui::ServerParser::parseCommand(const std::string& comm
                 arguments = parseMessage(stream, arguments, commandName);
                 return arguments;
             }
+            case Gui::ServerParser::ParseType::LIST_INT:
+            {
+                arguments = parseListInt(stream, arguments, commandName);
+                return arguments;
+            }
             default:
                 break;
         }
@@ -88,4 +93,19 @@ std::vector<std::string> Gui::ServerParser::parseMessage(std::istringstream& str
     std::getline(stream, end, '\0');
     arguments.push_back(start + end);
     return arguments;
+}
+
+std::vector<std::string> Gui::ServerParser::parseListInt(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName)
+{
+    if (stream.fail())
+        throw Errors::ServerParserException("Wrong parameters for '" + commandName + "' command.");
+    while (1) {
+        int player;
+        stream >> player;
+        if (stream.fail())
+            throw Errors::ServerParserException("Wrong parameters for '" + commandName + "' command.");
+        arguments.push_back(std::to_string(player));
+        if((stream.eof()))
+            return arguments;
+    }
 }

--- a/gui/src/Parsing/ServerParser.cpp
+++ b/gui/src/Parsing/ServerParser.cpp
@@ -42,6 +42,11 @@ std::vector<std::string> Gui::ServerParser::parseCommand(const std::string& comm
                 arguments = parseString(stream, arguments);
                 break;
             }
+            case Gui::ServerParser::ParseType::MESSAGE:
+            {
+                arguments = parseMessage(stream, arguments, commandName);
+                return arguments;
+            }
             default:
                 break;
         }
@@ -67,5 +72,20 @@ std::vector<std::string> Gui::ServerParser::parseString(std::istringstream& stre
     std::string str;
     stream >> str;
     arguments.push_back(str);
+    return arguments;
+}
+
+std::vector<std::string> Gui::ServerParser::parseMessage(std::istringstream& stream, std::vector<std::string> arguments, std::string commandName)
+{
+    if (stream.fail())
+        throw Errors::ServerParserException("Wrong parameters for '" + commandName + "' command.");
+
+    std::string start;
+    stream >> start;
+    if (stream.fail())
+        throw Errors::ServerParserException("Wrong parameters for '" + commandName + "' command.");
+    std::string end;
+    std::getline(stream, end, '\0');
+    arguments.push_back(start + end);
     return arguments;
 }

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -946,3 +946,43 @@ Test(ParseServer, sbp_too_long, .timeout = 5)
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'sbp' command.");
 }
+
+// command pie
+
+Test(ParseServer, correct_pie_command, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::vector<std::string> test;
+
+    test = parser.parse("pie 1 2 0");
+
+    cr_assert_eq(test[0], "1");
+    cr_assert_eq(test[1], "2");
+    cr_assert_eq(test[2], "0");
+}
+
+Test(ParseServer, pie_too_long, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pie 1 2 3 4");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Too many parameters for 'pie' command.");
+}
+
+Test(ParseServer, pie_wrong, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pie 1 wrong 0");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pie' command.");
+}

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -881,3 +881,73 @@ Test(ParseServer, smg_no_message, .timeout = 5)
     }
     cr_assert_str_eq(test.c_str(), "Wrong parameters for 'smg' command.");
 }
+
+// command pic
+
+Test(ParseServer, correct_pic_command, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::vector<std::string> test;
+
+    test = parser.parse("pic 1 2 3 9 8 7 6");
+
+    cr_assert_eq(test[0], "1");
+    cr_assert_eq(test[1], "2");
+    cr_assert_eq(test[2], "3");
+    cr_assert_eq(test[3], "9");
+    cr_assert_eq(test[4], "8");
+    cr_assert_eq(test[5], "7");
+    cr_assert_eq(test[6], "6");
+}
+
+Test(ParseServer, correct_pic_command_one_list, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::vector<std::string> test;
+
+    test = parser.parse("pic 1 2 3 9");
+
+    cr_assert_eq(test[0], "1");
+    cr_assert_eq(test[1], "2");
+    cr_assert_eq(test[2], "3");
+    cr_assert_eq(test[3], "9");
+}
+
+Test(ParseServer, pic_no_list, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pic 1 2 3 ");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pic' command.");
+}
+
+Test(ParseServer, pic_wrong_list, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pic 1 2 3 9 8 wrong");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pic' command.");
+}
+
+Test(ParseServer, pic_wrong, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pic 1 2 wrong 9 8 3");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pic' command.");
+}

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -817,3 +817,40 @@ Test(ParseServer, pie_wrong, .timeout = 5)
     }
     cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pie' command.");
 }
+
+Test(ParseServer, correct_pbc_command, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::vector<std::string> test;
+
+    test = parser.parse("pbc 1 test of   pbc command 1");
+
+    cr_assert_eq(test[0], "1");
+    cr_assert_eq(test[1], "test of   pbc command 1");
+}
+
+Test(ParseServer, pbc_wrong, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pbc wrong good good good");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pbc' command.");
+}
+
+Test(ParseServer, pbc_no_message, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("pbc 1");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pbc' command.");
+}

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -146,7 +146,7 @@ Test(ParseServer, correct_pnw_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pnw #1 2 3 4 5 team");
+    test = parser.parse("pnw 1 2 3 4 5 team");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -162,24 +162,11 @@ Test(ParseServer, pnw_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pnw #1 2 3 4 5 team team2");
+        parser.parse("pnw 1 2 3 4 5 team team2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pnw' command.");
-}
-
-Test(ParseServer, pnw_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pnw 1 2 3 4 5 team");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pnw' command.");
 }
 
 Test(ParseServer, pnw_wrong, .timeout = 5)
@@ -188,7 +175,7 @@ Test(ParseServer, pnw_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pnw #1 2 wrong 4 5 team");
+        parser.parse("pnw 1 2 wrong 4 5 team");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -202,7 +189,7 @@ Test(ParseServer, correct_ppo_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("ppo #1 2 3 4");
+    test = parser.parse("ppo 1 2 3 4");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -216,24 +203,11 @@ Test(ParseServer, ppo_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("ppo #1 2 3 4 5");
+        parser.parse("ppo 1 2 3 4 5");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'ppo' command.");
-}
-
-Test(ParseServer, ppo_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("ppo 1 2 3 4");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'ppo' command.");
 }
 
 Test(ParseServer, ppo_wrong, .timeout = 5)
@@ -242,7 +216,7 @@ Test(ParseServer, ppo_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("ppo #1 2 wrong 4");
+        parser.parse("ppo 1 2 wrong 4");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -256,7 +230,7 @@ Test(ParseServer, correct_plv_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("plv #1 2");
+    test = parser.parse("plv 1 2");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -268,24 +242,11 @@ Test(ParseServer, plv_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("plv #1 2 3");
+        parser.parse("plv 1 2 3");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'plv' command.");
-}
-
-Test(ParseServer, plv_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("plv 1 2");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'plv' command.");
 }
 
 Test(ParseServer, plv_wrong, .timeout = 5)
@@ -294,7 +255,7 @@ Test(ParseServer, plv_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("plv #1 wrong");
+        parser.parse("plv 1 wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -308,7 +269,7 @@ Test(ParseServer, correct_pin_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pin #1 2 3 0 1 2 3 4 5 6");
+    test = parser.parse("pin 1 2 3 0 1 2 3 4 5 6");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -323,24 +284,11 @@ Test(ParseServer, pin_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pin #1 2 3 0 1 2 3 4 5 6 7");
+        parser.parse("pin 1 2 3 0 1 2 3 4 5 6 7");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pin' command.");
-}
-
-Test(ParseServer, pin_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pin 1 2 3 0 1 2 3 4 5 6");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pin' command.");
 }
 
 Test(ParseServer, pin_wrong, .timeout = 5)
@@ -349,7 +297,7 @@ Test(ParseServer, pin_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pin #1 2 3 0 1 2 wrong 4 5 6");
+        parser.parse("pin 1 2 3 0 1 2 wrong 4 5 6");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -363,7 +311,7 @@ Test(ParseServer, correct_pex_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pex #1");
+    test = parser.parse("pex 1");
 
     cr_assert_eq(test[0], "1");
 }
@@ -374,24 +322,11 @@ Test(ParseServer, pex_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pex #1 2");
+        parser.parse("pex 1 2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pex' command.");
-}
-
-Test(ParseServer, pex_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pex 1");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pex' command.");
 }
 
 Test(ParseServer, pex_wrong, .timeout = 5)
@@ -400,7 +335,7 @@ Test(ParseServer, pex_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pex #wrong");
+        parser.parse("pex wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -414,7 +349,7 @@ Test(ParseServer, correct_pfk_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pfk #1");
+    test = parser.parse("pfk 1");
 
     cr_assert_eq(test[0], "1");
 }
@@ -425,24 +360,11 @@ Test(ParseServer, pfk_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pfk #1 2");
+        parser.parse("pfk 1 2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pfk' command.");
-}
-
-Test(ParseServer, pfk_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pfk 1");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pfk' command.");
 }
 
 Test(ParseServer, pfk_wrong, .timeout = 5)
@@ -451,7 +373,7 @@ Test(ParseServer, pfk_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pfk #wrong");
+        parser.parse("pfk wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -465,7 +387,7 @@ Test(ParseServer, correct_pdr_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pdr #1 2");
+    test = parser.parse("pdr 1 2");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -477,24 +399,11 @@ Test(ParseServer, pdr_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pdr #1 2 3");
+        parser.parse("pdr 1 2 3");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pdr' command.");
-}
-
-Test(ParseServer, pdr_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pdr 1 2");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pdr' command.");
 }
 
 Test(ParseServer, pdr_wrong, .timeout = 5)
@@ -503,7 +412,7 @@ Test(ParseServer, pdr_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pdr #1 a");
+        parser.parse("pdr 1 a");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -517,7 +426,7 @@ Test(ParseServer, correct_pgt_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pgt #1 2");
+    test = parser.parse("pgt 1 2");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -529,24 +438,11 @@ Test(ParseServer, pgt_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pgt #1 2 3");
+        parser.parse("pgt 1 2 3");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pgt' command.");
-}
-
-Test(ParseServer, pgt_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pgt 1 2");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pgt' command.");
 }
 
 Test(ParseServer, pgt_wrong, .timeout = 5)
@@ -555,7 +451,7 @@ Test(ParseServer, pgt_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pgt #1 a");
+        parser.parse("pgt 1 a");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -569,7 +465,7 @@ Test(ParseServer, correct_pdi_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("pdi #1");
+    test = parser.parse("pdi 1");
 
     cr_assert_eq(test[0], "1");
 }
@@ -580,24 +476,11 @@ Test(ParseServer, pdi_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pdi #1 2");
+        parser.parse("pdi 1 2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'pdi' command.");
-}
-
-Test(ParseServer, pdi_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("pdi 1");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pdi' command.");
 }
 
 Test(ParseServer, pdi_wrong, .timeout = 5)
@@ -606,7 +489,7 @@ Test(ParseServer, pdi_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("pdi #wrong");
+        parser.parse("pdi wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -620,7 +503,7 @@ Test(ParseServer, correct_enw_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("enw #1 #2 3 4");
+    test = parser.parse("enw 1 2 3 4");
 
     cr_assert_eq(test[0], "1");
     cr_assert_eq(test[1], "2");
@@ -634,37 +517,11 @@ Test(ParseServer, enw_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("enw #1 #2 3 4 5");
+        parser.parse("enw 1 2 3 4 5");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'enw' command.");
-}
-
-Test(ParseServer, enw_wrong_hashtag_egg, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("enw 1 #2 3 4");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'enw' command.");
-}
-
-Test(ParseServer, enw_wrong_hashtag_player, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("enw #1 2 3 4");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'enw' command.");
 }
 
 Test(ParseServer, enw_wrong, .timeout = 5)
@@ -673,7 +530,7 @@ Test(ParseServer, enw_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("enw #1 #2 wrong 4");
+        parser.parse("enw 1 2 wrong 4");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -687,7 +544,7 @@ Test(ParseServer, correct_ebo_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("ebo #1");
+    test = parser.parse("ebo 1");
 
     cr_assert_eq(test[0], "1");
 }
@@ -698,24 +555,11 @@ Test(ParseServer, ebo_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("ebo #1 2");
+        parser.parse("ebo 1 2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'ebo' command.");
-}
-
-Test(ParseServer, ebo_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("ebo 1");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'ebo' command.");
 }
 
 Test(ParseServer, ebo_wrong, .timeout = 5)
@@ -724,7 +568,7 @@ Test(ParseServer, ebo_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("ebo #wrong");
+        parser.parse("ebo wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }
@@ -738,7 +582,7 @@ Test(ParseServer, correct_edi_command, .timeout = 5)
     Gui::ServerParser parser;
     std::vector<std::string> test;
 
-    test = parser.parse("edi #1");
+    test = parser.parse("edi 1");
 
     cr_assert_eq(test[0], "1");
 }
@@ -749,24 +593,11 @@ Test(ParseServer, edi_too_long, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("edi #1 2");
+        parser.parse("edi 1 2");
     } catch (const std::exception &error) {
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Too many parameters for 'edi' command.");
-}
-
-Test(ParseServer, edi_wrong_hashtag, .timeout = 5)
-{
-    Gui::ServerParser parser;
-    std::string test;
-
-    try {
-        parser.parse("edi 1");
-    } catch (const std::exception &error) {
-        test = error.what();
-    }
-    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'edi' command.");
 }
 
 Test(ParseServer, edi_wrong, .timeout = 5)
@@ -775,7 +606,7 @@ Test(ParseServer, edi_wrong, .timeout = 5)
     std::string test;
 
     try {
-        parser.parse("edi #wrong");
+        parser.parse("edi wrong");
     } catch (const std::exception &error) {
         test = error.what();
     }

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -818,6 +818,8 @@ Test(ParseServer, pie_wrong, .timeout = 5)
     cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pie' command.");
 }
 
+// command pbc
+
 Test(ParseServer, correct_pbc_command, .timeout = 5)
 {
     Gui::ServerParser parser;
@@ -853,4 +855,29 @@ Test(ParseServer, pbc_no_message, .timeout = 5)
         test = error.what();
     }
     cr_assert_str_eq(test.c_str(), "Wrong parameters for 'pbc' command.");
+}
+
+// command smg
+
+Test(ParseServer, correct_smg_command, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::vector<std::string> test;
+
+    test = parser.parse("smg test of   smg command 1");
+
+    cr_assert_eq(test[0], "test of   smg command 1");
+}
+
+Test(ParseServer, smg_no_message, .timeout = 5)
+{
+    Gui::ServerParser parser;
+    std::string test;
+
+    try {
+        parser.parse("smg ");
+    } catch (const std::exception &error) {
+        test = error.what();
+    }
+    cr_assert_str_eq(test.c_str(), "Wrong parameters for 'smg' command.");
 }


### PR DESCRIPTION
I added the following server commands to the parsing: smg, pic, pbc and pie.
Moreover I remove the hashtag from the parsing, now the '#player' is just 'player'. 

More details : #15 