### PR TITLE
feat: add tests for the team zappy gui

### DIFF
--- a/gui/Makefile
+++ b/gui/Makefile
@@ -28,6 +28,7 @@ TEST_FILES	=	Network/TestNetwork.cpp \
 				GameDatas/TestInventory.cpp \
 				GameDatas/TestPlayer.cpp \
 				GameDatas/TestTile.cpp \
+				GameDatas/TestTeam.cpp \
 
 OBJ			=	$(SRC:.cpp=.o)
 MAIN_OBJ	=	$(MAIN:.cpp=.o)
@@ -36,7 +37,7 @@ MAIN_OBJ	=	$(MAIN:.cpp=.o)
 NAME		= 	zappy_gui
 
 # Flags
-INCLUDE		= 	-I./include
+INCLUDE		= 	-I./include -I./tests
 CXXFLAGS 	= 	-std=c++20 -Wall -Wextra -Werror
 
 # Colors

--- a/gui/include/GameDatas/Team.hpp
+++ b/gui/include/GameDatas/Team.hpp
@@ -55,6 +55,13 @@ class Gui::Team {
         std::vector<Gui::Player> &getPlayers();
 
         /**
+         * @brief Set the Name object.
+         *
+         * @param name Name of the team.
+        */
+        void setName(const std::string &name);
+
+        /**
          * @brief Add a player to the team.
          *
          * @param player Player to add.

--- a/gui/src/GameDatas/Team.cpp
+++ b/gui/src/GameDatas/Team.cpp
@@ -14,6 +14,11 @@ const std::string &Gui::Team::getName() const
     return _name;
 }
 
+void Gui::Team::setName(const std::string &name)
+{
+    _name = name;
+}
+
 std::vector<Gui::Player> &Gui::Team::getPlayers()
 {
     return _players;

--- a/gui/tests/CriterionHeaders.hpp
+++ b/gui/tests/CriterionHeaders.hpp
@@ -1,0 +1,11 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** CriterionHeaders
+*/
+
+#pragma once
+
+#include <criterion/criterion.h>
+#include <criterion/redirect.h>

--- a/gui/tests/GameDatas/TestInventory.cpp
+++ b/gui/tests/GameDatas/TestInventory.cpp
@@ -5,10 +5,8 @@
 ** test inventory
 */
 
+#include "CriterionHeaders.hpp"
 #include "GameDatas/Inventory.hpp"
-
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 
 Test(Inventory, Food, .timeout = 5)
 {

--- a/gui/tests/GameDatas/TestPlayer.cpp
+++ b/gui/tests/GameDatas/TestPlayer.cpp
@@ -6,9 +6,7 @@
 */
 
 #include "GameDatas/Player.hpp"
-
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
+#include "CriterionHeaders.hpp"
 
 Test(Player, position, .timeout = 5)
 {

--- a/gui/tests/GameDatas/TestTeam.cpp
+++ b/gui/tests/GameDatas/TestTeam.cpp
@@ -1,0 +1,102 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** TestTeam
+*/
+
+#include "GameDatas/Team.hpp"
+#include "CriterionHeaders.hpp"
+
+Test(Team, name, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    cr_assert_eq(team.getName(), "TEAM1");
+
+    team.setName("TEAM2");
+    cr_assert_eq(team.getName(), "TEAM2");
+}
+
+Test(Team, players, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.getPlayers().push_back(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+    cr_assert_eq(team.getPlayers()[0].getId(), 3);
+    cr_assert_eq(team.getPlayers()[0].getTeam(), "TEAM1");
+    cr_assert_eq(team.getPlayers()[0].getPosition().first, 1);
+    cr_assert_eq(team.getPlayers()[0].getPosition().second, 2);
+}
+
+Test(Team, addPlayer, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.addPlayer(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+    cr_assert_eq(team.getPlayers()[0].getId(), 3);
+    cr_assert_eq(team.getPlayers()[0].getTeam(), "TEAM1");
+    cr_assert_eq(team.getPlayers()[0].getPosition().first, 1);
+    cr_assert_eq(team.getPlayers()[0].getPosition().second, 2);
+}
+
+Test(Team, removePlayer, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.addPlayer(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+
+    team.removePlayer(3);
+    cr_assert_eq(team.getPlayers().size(), 0);
+}
+
+Test(Team, getPlayer, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.addPlayer(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+
+    auto player2 = team.getPlayer(3);
+    cr_assert_eq(player2->getId(), 3);
+    cr_assert_eq(player2->getTeam(), "TEAM1");
+    cr_assert_eq(player2->getPosition().first, 1);
+    cr_assert_eq(player2->getPosition().second, 2);
+}
+
+Test(Team, getPlayerFailing, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.addPlayer(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+
+    auto player2 = team.getPlayer(4);
+    cr_assert_eq(player2, nullptr);
+}
+
+Test(Team, removePlayerFailing, .timeout = 5)
+{
+    Gui::Team team("TEAM1");
+
+    Gui::Player player(3, "TEAM1", std::pair<std::size_t, std::size_t>(1, 2));
+    team.addPlayer(player);
+
+    cr_assert_eq(team.getPlayers().size(), 1);
+
+    team.removePlayer(4);
+    cr_assert_eq(team.getPlayers().size(), 1);
+}

--- a/gui/tests/GameDatas/TestTile.cpp
+++ b/gui/tests/GameDatas/TestTile.cpp
@@ -6,9 +6,7 @@
 */
 
 #include "GameDatas/Tile.hpp"
-
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
+#include "CriterionHeaders.hpp"
 
 Test(Tile, position, .timeout = 5)
 {

--- a/gui/tests/Network/TestNetwork.cpp
+++ b/gui/tests/Network/TestNetwork.cpp
@@ -6,9 +6,7 @@
 */
 
 #include "Network/Network.hpp"
-
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
+#include "CriterionHeaders.hpp"
 
 
 // Port tests

--- a/gui/tests/Parsing/TestParseCommandLine.cpp
+++ b/gui/tests/Parsing/TestParseCommandLine.cpp
@@ -5,10 +5,9 @@
 ** test parseCommandLine
 */
 
+#include "CriterionHeaders.hpp"
 #include "Parsing/ParseCommandLine.hpp"
 
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 #include <stdlib.h>
 
 Test(ParseCommandLine, command_correct, .timeout = 5)

--- a/gui/tests/Parsing/TestParser.cpp
+++ b/gui/tests/Parsing/TestParser.cpp
@@ -5,10 +5,8 @@
 ** test Msz command
 */
 
+#include "CriterionHeaders.hpp"
 #include "Parsing/ServerParser.hpp"
-
-#include <criterion/criterion.h>
-#include <criterion/redirect.h>
 
 Test(ParseServer, unknown_command, .timeout = 5)
 {


### PR DESCRIPTION
I added the missing tests for the `Team` class. 

I also created a criterion header include file to avoid code duplication for the tests.

To see details on the `Team` class, check this issue: #32 