### PR TITLE
Refactor/move gui binary in root and fix assets zappy gui

### DIFF
--- a/gui/Makefile
+++ b/gui/Makefile
@@ -72,14 +72,14 @@ $(NAME): $(OBJ) $(MAIN_OBJ)
 	@$(CC) $(MAIN_OBJ) $(OBJ) -o $(NAME) $(CXXFLAGS) $(INCLUDE) && \
 	$(call YELLOW,"✅ $@") || \
 	$(call YELLOW,"❌ $@")
-	cp $(NAME) ../
+	mv $(NAME) ../
 
 clean:
 	rm -f $(MAIN_OBJ) $(OBJ)
 	@$(call GREEN,"✅ [$@] done !")
 
 fclean: clean tests_clean
-	@rm -f $(NAME) $(TEST_NAME)
+	@rm -f $(TEST_NAME)
 	@rm -f ../$(NAME)
 	@$(call GREEN,"✅ [$@] done !")
 

--- a/gui/include/Assets.hpp
+++ b/gui/include/Assets.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#define PATH_ASSETS                 "assets/"
+#define PATH_ASSETS                 "gui/assets/"
 
 #define MODEL_TILE                  PATH_ASSETS "tile.glb"
 #define MODEL_FOOD                  PATH_ASSETS "food.glb"


### PR DESCRIPTION
I change the way the binary is created by move it at the root instead of copy it.
I also change the path to the assets.

Now, the zappy_gui binary must be executed at the root.

More details : #74 