### PR TITLE
Feat/implement clicks for tiles

### DIFF
--- a/gui/include/Event/Event.hpp
+++ b/gui/include/Event/Event.hpp
@@ -137,6 +137,11 @@ class Gui::Event {
         void selectPlayer();
 
         /**
+         * @brief Select the tile.
+        */
+        void selectTile();
+
+        /**
          * @brief Change the player.
          *
          * @param turn Turn to select the player.

--- a/gui/include/GameDatas/Tile.hpp
+++ b/gui/include/GameDatas/Tile.hpp
@@ -10,6 +10,8 @@
 #include "raylib.h"
 #include "GameDatas/Inventory.hpp"
 
+#include <vector>
+
 namespace Gui {
 
     /**
@@ -64,6 +66,33 @@ class Gui::Tile {
          * @return Vector3 - Position in space.
          */
         Vector3 getPositionIn3DSpace();
+
+        /**
+         * @brief Get the Tile Bounding Boxes object.
+         *
+         * @param tile Tile to get the bounding boxes.
+         * @return std::vector<BoundingBox> - Bounding boxes of the tile.
+        */
+        std::vector<BoundingBox> getTileBoundingBoxes(Tile tile, Model tileModel);
+
+        /**
+         * @brief Get the Tile Model Hitbox object.
+         *
+         * @param tile Tile to get the hitbox.
+         * @param camera Camera to get the hitbox.
+         * @return std::vector<RayCollision> - Hitbox of the tile.
+         */
+        std::vector<RayCollision> getTileModelHitbox(Tile tile, Camera camera, Model tileModel);
+
+        /**
+         * @brief Check if the tile is hit.
+         *
+         * @param camera Camera to check if the tile is hit.
+         * @param _tileModel Model of the tile.
+         * @return true - The tile is hit.
+         * @return false - The tile is not hit.
+         */
+        bool isTileHit(Camera camera, Model _tileModel);
 
         /**
          * @brief Inventory of the tile.

--- a/gui/include/GameDatas/Tile.hpp
+++ b/gui/include/GameDatas/Tile.hpp
@@ -56,14 +56,14 @@ class Gui::Tile {
          *
          * @return std::pair<std::size_t, std::size_t> - position x y
          */
-        std::pair<std::size_t, std::size_t> getPosition(void) const;
+        std::pair<std::size_t, std::size_t> getPosition() const;
 
         /**
          * @brief Get the Position In Space object.
          *
          * @return Vector3 - Position in space.
          */
-        Vector3 getPositionIn3DSpace(void);
+        Vector3 getPositionIn3DSpace();
 
         /**
          * @brief Inventory of the tile.

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -155,6 +155,12 @@ class Gui::Render {
         void displayMap(void);
 
         /**
+         * @brief Display a Tile.
+         *
+        */
+        void displayTile(Tile tile);
+
+        /**
          * @brief Display the eggs.
          *
          * @param tile Tile with eggs.

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -108,6 +108,12 @@ class Gui::Render {
          */
         std::size_t getCameraPlayerPov() const;
 
+        /**
+         * @brief Get the Tile model.
+         *
+        */
+        Model getTileModel() const;
+
     private:
 
         UserCamera                  _camera;            // Camera of the scene.

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -98,8 +98,10 @@ void Gui::Event::selectPlayer()
                         DrawBoundingBox(bboxes[i], RED);
                 }
             }
-            if (team.isPlayerHit(player.getId(), *_render.get()->getCamera().get()))
+            if (team.isPlayerHit(player.getId(), *_render.get()->getCamera().get())) {
+                // TODO: Display the player HUD
                 this->changeCameraToPlayer(player.getId());
+            }
         }
     }
     EndMode3D();

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -70,9 +70,10 @@ void Gui::Event::setFreeCam()
 
 void Gui::Event::handleLeftClick()
 {
-    if (_render->getCameraType() == Gui::UserCamera::CameraType::FREE)
+    if (_render->getCameraType() == Gui::UserCamera::CameraType::FREE) {
         selectPlayer();
-    else
+        selectTile();
+    } else
         changePlayer(true);
 }
 
@@ -99,6 +100,30 @@ void Gui::Event::selectPlayer()
             }
             if (team.isPlayerHit(player.getId(), *_render.get()->getCamera().get()))
                 this->changeCameraToPlayer(player.getId());
+        }
+    }
+    EndMode3D();
+    EndDrawing();
+}
+
+void Gui::Event::selectTile()
+{
+    BeginDrawing();
+    BeginMode3D(*_render.get()->getCamera().get());
+    for (auto &line : _gameData.get()->getMap()) {
+        for (auto &tile : line) {
+            if (_render.get()->getIsDebug()) {
+                std::vector<BoundingBox> bboxes = tile.getTileBoundingBoxes(tile, _render.get()->getTileModel());
+                std::vector<RayCollision> hitbox = tile.getTileModelHitbox(tile, *_render.get()->getCamera().get(), _render.get()->getTileModel());
+
+                for (size_t i = 0; i < bboxes.size(); i++) {
+                    if (hitbox[i].hit)
+                        DrawBoundingBox(bboxes[i], RED);
+                }
+            }
+            if (tile.isTileHit(*_render.get()->getCamera().get(), _render.get()->getTileModel()))
+                // TODO: Display the HUD of the tile
+                std::cout << "Tile hit" << std::endl;
         }
     }
     EndMode3D();

--- a/gui/src/GameDatas/Tile.cpp
+++ b/gui/src/GameDatas/Tile.cpp
@@ -33,3 +33,44 @@ Vector3 Gui::Tile::getPositionIn3DSpace()
 {
     return _positionIn3DSpace;
 }
+
+std::vector<BoundingBox> Gui::Tile::getTileBoundingBoxes(Tile tile, Model tileModel)
+{
+    std::vector<BoundingBox> bboxes;
+
+    for (int i = 0; i < tileModel.meshCount; i++) {
+        BoundingBox bbox = GetMeshBoundingBox(tileModel.meshes[i]);
+        bbox.min.x += tile.getPositionIn3DSpace().x;
+        bbox.min.y += tile.getPositionIn3DSpace().y;
+        bbox.min.z += tile.getPositionIn3DSpace().z;
+        bbox.max.x += tile.getPositionIn3DSpace().x;
+        bbox.max.y += tile.getPositionIn3DSpace().y;
+        bbox.max.z += tile.getPositionIn3DSpace().z;
+        bboxes.push_back(bbox);
+    }
+    return bboxes;
+}
+
+std::vector<RayCollision> Gui::Tile::getTileModelHitbox(Tile tile, Camera camera, Model tileModel)
+{
+    std::vector<BoundingBox> towerBBox = tile.getTileBoundingBoxes(tile, tileModel);
+    std::vector<RayCollision> boxHitInfo;
+
+    Ray ray = GetMouseRay((Vector2){(float)GetScreenWidth() / 2, (float)GetScreenHeight() / 2}, camera);
+
+    for (size_t i = 0; i < towerBBox.size(); i++)
+        boxHitInfo.push_back(GetRayCollisionBox(ray, towerBBox[i]));
+    return boxHitInfo;
+}
+
+bool Gui::Tile::isTileHit(Camera camera, Model _tileModel)
+{
+    std::vector<BoundingBox> towerBBox = getTileBoundingBoxes(*this, _tileModel);
+    std::vector<RayCollision> boxHitInfo = getTileModelHitbox(*this, camera, _tileModel);
+
+    for (size_t i = 0; i < towerBBox.size(); i++) {
+        if (boxHitInfo[i].hit)
+            return true;
+    }
+    return false;
+}

--- a/gui/src/GameDatas/Tile.cpp
+++ b/gui/src/GameDatas/Tile.cpp
@@ -24,12 +24,12 @@ void Gui::Tile::setPosition(std::pair<std::size_t, std::size_t> position)
     _positionIn3DSpace = (Vector3) {(float)(position.first * SIZE_TILE), 0.0f, (float)(position.second * SIZE_TILE)};
 }
 
-std::pair<std::size_t, std::size_t> Gui::Tile::getPosition(void) const
+std::pair<std::size_t, std::size_t> Gui::Tile::getPosition() const
 {
     return _position;
 }
 
-Vector3 Gui::Tile::getPositionIn3DSpace(void)
+Vector3 Gui::Tile::getPositionIn3DSpace()
 {
     return _positionIn3DSpace;
 }

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -121,12 +121,22 @@ void Gui::Render::displayMap()
 {
     for (auto &line : _gameData->getMap()) {
         for (auto &tile : line) {
-            DrawModel(_tileModel, tile.getPositionIn3DSpace(), 1.0f, WHITE);
+            displayTile(tile);
             displayFood(tile);
             displayResources(tile);
             displayEggs(tile);
             _decoration->display(_gameData->getMapSize());
         }
+    }
+}
+
+void Gui::Render::displayTile(Tile tile)
+{
+    DrawModel(_tileModel, tile.getPositionIn3DSpace(), 1.0f, WHITE);
+    if (_isDebug) {
+        std::vector<BoundingBox> bboxes = tile.getTileBoundingBoxes(tile, _tileModel);
+        for (size_t i = 0; i < bboxes.size(); i++)
+            DrawBoundingBox(bboxes[i], GREEN);
     }
 }
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -73,12 +73,12 @@ void Gui::Render::setIsDebug(bool isDebug)
     _isDebug = isDebug;
 }
 
-bool Gui::Render::getIsDebug(void)
+bool Gui::Render::getIsDebug()
 {
     return _isDebug;
 }
 
-void Gui::Render::displayDebug(void)
+void Gui::Render::displayDebug()
 {
     if (_isDebug) {
         DrawFPS(10, 10);
@@ -95,7 +95,7 @@ void Gui::Render::displayDebug(void)
     }
 }
 
-void Gui::Render::displayPlayers(void)
+void Gui::Render::displayPlayers()
 {
     for (auto &team : _gameData->getTeams()) {
         for (auto &player : team.getPlayers()) {
@@ -117,7 +117,7 @@ void Gui::Render::displayPlayers(void)
     }
 }
 
-void Gui::Render::displayMap(void)
+void Gui::Render::displayMap()
 {
     for (auto &line : _gameData->getMap()) {
         for (auto &tile : line) {

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -242,3 +242,8 @@ std::size_t Gui::Render::getCameraPlayerPov() const
 {
     return _camera.getPlayerId();
 }
+
+Model Gui::Render::getTileModel() const
+{
+    return _tileModel;
+}


### PR DESCRIPTION
I added the Tiles hitboxes and detection.

At the moment, you can click on a tile *(with debug off)* and it will display a text to say that the tile has been hit:

![image](https://github.com/FppEpitech/Zappy/assets/114673563/d66e8f5d-bb8a-4963-9c6c-2d4ab53d2681)

> [!Note]
> The Hud will be done in this issue: #90 

When the debug is on, you can see the tile hitboxes, and click on hit (It will do nothing but change to red the color of the touched hitbox)

> [!Note]
> Obviously, the HUD is not displayed when debug is on.


Here the map with the tile hitboxes:

![image](https://github.com/FppEpitech/Zappy/assets/114673563/48a00483-1b8b-43db-848d-098d101bfaca)


> [!Note]
> Since i need the raylib `Model` class to implement the features, the code is not testable