### PR TITLE
Feat/implement chunks and render distance zappy gui

### DIFF
--- a/gui/include/Assets.hpp
+++ b/gui/include/Assets.hpp
@@ -32,10 +32,6 @@
 #define MODEL_TREE                  PATH_ASSETS PATH_DECORATION "tree.glb"
 #define MODEL_LANTERN               PATH_ASSETS PATH_DECORATION "lantern.glb"
 
-#define SIZE_TILE                   4.7
-
-#define PLAYER_HEIGHT               2
-
 #define SCALE_FOOD                  (Vector3){1, 0.5, 1}
 #define SCALE_LINEMATE              (Vector3){0.1, 0.1, 0.1}
 #define SCALE_MENDIANE              (Vector3){0.1, 0.1, 0.1}

--- a/gui/include/Config.hpp
+++ b/gui/include/Config.hpp
@@ -1,0 +1,14 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** Config
+*/
+
+#pragma once
+
+#define SIZE_TILE                   4.7
+
+#define PLAYER_HEIGHT               2
+
+#define DEFAULT_RENDER_DISTANCE     5

--- a/gui/include/Config.hpp
+++ b/gui/include/Config.hpp
@@ -12,3 +12,5 @@
 #define PLAYER_HEIGHT               2
 
 #define DEFAULT_RENDER_DISTANCE     5
+#define MAX_RENDER_DISTANCE         15
+#define MIN_RENDER_DISTANCE         1

--- a/gui/include/Event/Event.hpp
+++ b/gui/include/Event/Event.hpp
@@ -72,7 +72,7 @@ class Gui::Event {
         std::unordered_map<KeyboardKey, std::function<void()>> _eventsKeyDown =
         {
             {KEY_SPACE, [this](){moveUpCamera();}},
-            {KEY_LEFT_SHIFT, [this](){moveDownCamera();}}
+            {KEY_LEFT_SHIFT, [this](){moveDownCamera();}},
         };
 
         /**
@@ -84,7 +84,9 @@ class Gui::Event {
             {KEY_THREE, [this](){switchDisplayDebug();}},
             {KEY_F3, [this](){switchDisplayDebug();}},
             {KEY_SPACE, [this](){setFreeCam();}},
-            {KEY_R, [this](){switchTileHudToGame();}}
+            {KEY_R, [this](){switchTileHudToGame();}},
+            {KEY_J, [this](){increaseRenderDistance();}},
+            {KEY_K, [this](){decreaseRenderDistance();}},
         };
 
         /**
@@ -161,4 +163,16 @@ class Gui::Event {
          *
          */
         void switchTileHudToGame();
+
+        /**
+         * @brief Increase the render distance.
+         *
+         */
+        void increaseRenderDistance();
+
+        /**
+         * @brief Decrease the render distance.
+         *
+         */
+        void decreaseRenderDistance();
 };

--- a/gui/include/Render/Decoration.hpp
+++ b/gui/include/Render/Decoration.hpp
@@ -44,8 +44,10 @@ class Gui::Decoration {
          * @brief Display decorations.
          *
          * @param mapSize Size of the map.
+         * @param renderDistance Distance to render.
+         * @param camPos Position of the camera.
          */
-        void display(std::pair<std::size_t, std::size_t> mapSize);
+        void display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos);
 
         /**
          * @brief Generate random emplacement for decorations.

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -267,4 +267,11 @@ class Gui::Render {
          *
          */
         void displayCursor();
+
+        /**
+         * @brief Get the closest tile from the camera.
+         *
+         * @return std::pair<std::size_t, std::size_t> - Tile position.
+        */
+        std::pair<std::size_t, std::size_t> getCameraTile();
 };

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -131,6 +131,19 @@ class Gui::Render {
         */
         Model getTileModel() const;
 
+        /**
+         * @brief Set the Render Distance value.
+         *
+         * @param renderDistance New render distance value.
+         */
+        void setRenderDistance(size_t renderDistance);
+
+        /**
+         * @brief Get the Render Distance value.
+         *
+        */
+        size_t getRenderDistance() const;
+
     private:
 
         UserCamera                                  _camera;            // Camera of the scene.
@@ -138,6 +151,7 @@ class Gui::Render {
         std::shared_ptr<GameData>                   _gameData;          // GameData class to store the game's data.
         std::shared_ptr<Decoration>                 _decoration;        // Decoration to display;
         std::vector<std::shared_ptr<Gui::IHud>>     _hudList;           // List of huds.
+        size_t                                     _renderDistance;    // Distance to render from the 3d position of the camera.
 
         Model                                       _tileModel;         // Model to display tiles.
         Model                                       _foodModel;         // Model to display foods.

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -202,3 +202,13 @@ void Gui::Event::switchTileHudToGame()
     if (_render.get()->getCameraType() == Gui::UserCamera::FREE_TILE)
         _render.get()->setCameraType(Gui::UserCamera::FREE);
 }
+
+void Gui::Event::increaseRenderDistance()
+{
+    _render.get()->setRenderDistance(_render.get()->getRenderDistance() + 1);
+}
+
+void Gui::Event::decreaseRenderDistance()
+{
+    _render.get()->setRenderDistance(_render.get()->getRenderDistance() - 1);
+}

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -7,6 +7,7 @@
 
 #include "raylib.h"
 #include "Assets.hpp"
+#include "Config.hpp"
 #include "Event/Event.hpp"
 
 Gui::Event::Event()

--- a/gui/src/GameDatas/Player.cpp
+++ b/gui/src/GameDatas/Player.cpp
@@ -5,7 +5,7 @@
 ** Player
 */
 
-#include "Assets.hpp"
+#include "Config.hpp"
 #include "GameDatas/Player.hpp"
 
 Gui::Player::Player(std::size_t id, const std::string &team, std::pair<std::size_t, std::size_t> position, std::size_t orientation, std::size_t level) : _id(id), _team(team), _position(position), _orientation(orientation), _level(level), _state(Gui::Player::IDLE)

--- a/gui/src/GameDatas/Team.cpp
+++ b/gui/src/GameDatas/Team.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Assets.hpp"
+#include "Config.hpp"
 #include "GameDatas/Team.hpp"
 #include "raymath.h"
 

--- a/gui/src/GameDatas/Tile.cpp
+++ b/gui/src/GameDatas/Tile.cpp
@@ -5,7 +5,7 @@
 ** Tile
 */
 
-#include "Assets.hpp"
+#include "Config.hpp"
 #include "GameDatas/Tile.hpp"
 
 Gui::Tile::Tile(std::pair<std::size_t, std::size_t> position)

--- a/gui/src/Render/Decoration.cpp
+++ b/gui/src/Render/Decoration.cpp
@@ -11,6 +11,7 @@
 Gui::Decoration::Decoration()
 {
     _treeModel = LoadModel(MODEL_TREE);
+    _lanternModel = LoadModel(MODEL_LANTERN);
 }
 
 Map<bool> Gui::Decoration::getGenerationItem(std::size_t ratio)
@@ -33,6 +34,7 @@ void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_
     if (mapSize != _mapSize) {
         _mapSize = mapSize;
         _mapTree = getGenerationItem(5);
+        _mapLantern = getGenerationItem(3);
     }
 
     for (int i = 0; i < (int)_mapSize.first; i++) {
@@ -40,6 +42,7 @@ void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_
             if (i > (int)(camPos.first - renderDistance) && i < (int)(camPos.first + renderDistance) && j > (int)(camPos.second - renderDistance) && j < (int)(camPos.second + renderDistance)) {
                 Vector3 posTile = {(float)(i * SIZE_TILE), 0.0f, (float)(j * SIZE_TILE)};
                 displayTree(i, j, posTile);
+                displayLantern(i, j, posTile);
             }
         }
     }

--- a/gui/src/Render/Decoration.cpp
+++ b/gui/src/Render/Decoration.cpp
@@ -28,18 +28,19 @@ Map<bool> Gui::Decoration::getGenerationItem(std::size_t ratio)
     return map;
 }
 
-void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize)
+void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos)
 {
     if (mapSize != _mapSize) {
         _mapSize = mapSize;
         _mapTree = getGenerationItem(5);
     }
 
-    for (size_t i = 0; i < _mapSize.first; i++) {
-        for (size_t j = 0; j < _mapSize.second; j++) {
-            Vector3 posTile = {(float)(i * SIZE_TILE), 0.0f, (float)(j * SIZE_TILE)};
-            displayTree(i, j, posTile);
+    for (int i = 0; i < (int)_mapSize.first; i++) {
+        for (int j = 0; j < (int)_mapSize.second; j++) {
+            if (i > (int)(camPos.first - renderDistance) && i < (int)(camPos.first + renderDistance) && j > (int)(camPos.second - renderDistance) && j < (int)(camPos.second + renderDistance)) {
+                Vector3 posTile = {(float)(i * SIZE_TILE), 0.0f, (float)(j * SIZE_TILE)};
                 displayTree(i, j, posTile);
+            }
         }
     }
 }

--- a/gui/src/Render/Decoration.cpp
+++ b/gui/src/Render/Decoration.cpp
@@ -5,6 +5,7 @@
 ** Decoration
 */
 
+#include "Config.hpp"
 #include "Render/Decoration.hpp"
 
 Gui::Decoration::Decoration()

--- a/gui/src/Render/Decoration.cpp
+++ b/gui/src/Render/Decoration.cpp
@@ -11,7 +11,6 @@
 Gui::Decoration::Decoration()
 {
     _treeModel = LoadModel(MODEL_TREE);
-    //TODO : Unlock when multithreading: _lanternModel = LoadModel(MODEL_LANTERN);
 }
 
 Map<bool> Gui::Decoration::getGenerationItem(std::size_t ratio)
@@ -34,14 +33,13 @@ void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize)
     if (mapSize != _mapSize) {
         _mapSize = mapSize;
         _mapTree = getGenerationItem(5);
-        //TODO : Unlock when multithreading: _mapLantern = getGenerationItem(3);
     }
 
     for (size_t i = 0; i < _mapSize.first; i++) {
         for (size_t j = 0; j < _mapSize.second; j++) {
             Vector3 posTile = {(float)(i * SIZE_TILE), 0.0f, (float)(j * SIZE_TILE)};
             displayTree(i, j, posTile);
-            //TODO : Unlock when multithreading: displayLantern(i, j, posTile);
+                displayTree(i, j, posTile);
         }
     }
 }

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -147,6 +147,7 @@ void Gui::Render::displayDebug()
             std::to_string(_camera.getCamera()->target.y) + " / " +
             std::to_string(_camera.getCamera()->target.z)
             ).c_str(), 10, 50, 20, LIME);
+        DrawText(("Render distance: " + std::to_string(_renderDistance) + " chunks.").c_str(), 10, 70, 20, LIME);
     }
 }
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -23,6 +23,7 @@ Gui::Render::Render(std::shared_ptr<GameData> gameData)
     _hudList.push_back(std::make_shared<HudTile>(HudTile(gameData)));
     _decoration = std::make_shared<Decoration>(Decoration());
     this->LoadModels();
+    _renderDistance = 5;
 }
 
 void Gui::Render::LoadModels(void)
@@ -83,6 +84,17 @@ void Gui::Render::setIsDebug(bool isDebug)
 bool Gui::Render::getIsDebug()
 {
     return _isDebug;
+}
+void Gui::Render::setRenderDistance(size_t renderDistance)
+{
+    if (renderDistance < 1)
+        renderDistance = 1;
+    _renderDistance = renderDistance;
+}
+
+size_t Gui::Render::getRenderDistance() const
+{
+    return _renderDistance;
 }
 
 void Gui::Render::displayDebug()

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Assets.hpp"
+#include "Config.hpp"
 #include "Render/Render.hpp"
 
 #include <string>

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -149,6 +149,7 @@ void Gui::Render::displayDebug()
             std::to_string(_camera.getCamera()->target.z)
             ).c_str(), 10, 50, 20, LIME);
         DrawText(("Render distance: " + std::to_string(_renderDistance) + " chunks.").c_str(), 10, 70, 20, LIME);
+        DrawText(("Camera Tile XZ: " + std::to_string(getCameraTile().first) + " / " + std::to_string(getCameraTile().second)).c_str(), 10, 90, 20, LIME);
     }
 }
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -155,10 +155,16 @@ void Gui::Render::displayDebug()
 
 void Gui::Render::displayPlayers()
 {
+    std::pair<size_t, size_t> camTile = getCameraTile();
+
     for (auto &team : _gameData->getTeams()) {
         for (auto &player : team.getPlayers()) {
             if (_gameData.get()->getMap().size() == 0 || _gameData.get()->getMap()[player.getPosition().first].size() == 0)
                 return;
+            if (abs(player.getPosition().first - camTile.first) > (_renderDistance - 1) || abs(player.getPosition().second - camTile.second) > (_renderDistance - 1))
+                continue;
+            if (abs(player.getPosition().first - camTile.first) == (_renderDistance - 1) && abs(player.getPosition().second - camTile.second) == (_renderDistance - 1))
+                continue;
 
             float rotation = player.getRotationFromOrientation();
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -124,8 +124,10 @@ Model Gui::Render::getTileModel() const
 
 void Gui::Render::setRenderDistance(size_t renderDistance)
 {
-    if (renderDistance < 1)
-        renderDistance = 1;
+    if (renderDistance < MIN_RENDER_DISTANCE)
+        renderDistance = MIN_RENDER_DISTANCE;
+    if (renderDistance > MAX_RENDER_DISTANCE)
+        renderDistance = MAX_RENDER_DISTANCE;
     _renderDistance = renderDistance;
 }
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -85,6 +85,42 @@ bool Gui::Render::getIsDebug()
 {
     return _isDebug;
 }
+
+void Gui::Render::setCameraType(Gui::UserCamera::CameraType type)
+{
+    _camera.setType(type);
+}
+
+Gui::UserCamera::CameraType Gui::Render::getCameraType() const
+{
+    return _camera.getType();
+}
+
+void Gui::Render::setCameraPlayerPov(std::size_t id)
+{
+    _camera.setPlayerId(id);
+}
+
+std::size_t Gui::Render::getCameraPlayerPov() const
+{
+    return _camera.getPlayerId();
+}
+
+void Gui::Render::setCameraTile(std::pair<std::size_t, std::size_t> pos)
+{
+    _camera.setTilePos(pos);
+}
+
+std::pair<std::size_t, std::size_t> Gui::Render::getCameraTile() const
+{
+    return _camera.getTilePos();
+}
+
+Model Gui::Render::getTileModel() const
+{
+    return _tileModel;
+}
+
 void Gui::Render::setRenderDistance(size_t renderDistance)
 {
     if (renderDistance < 1)
@@ -272,39 +308,4 @@ void Gui::Render::displayCursor()
 {
     if (_camera.getType() != Gui::UserCamera::POV_PLAYER)
         DrawTexture(_cursorTexture, GetScreenWidth() / 2 - _cursorTexture.width / 2, GetScreenHeight() / 2 - _cursorTexture.height / 2, BLACK);
-}
-
-void Gui::Render::setCameraType(Gui::UserCamera::CameraType type)
-{
-    _camera.setType(type);
-}
-
-Gui::UserCamera::CameraType Gui::Render::getCameraType() const
-{
-    return _camera.getType();
-}
-
-void Gui::Render::setCameraPlayerPov(std::size_t id)
-{
-    _camera.setPlayerId(id);
-}
-
-std::size_t Gui::Render::getCameraPlayerPov() const
-{
-    return _camera.getPlayerId();
-}
-
-void Gui::Render::setCameraTile(std::pair<std::size_t, std::size_t> pos)
-{
-    _camera.setTilePos(pos);
-}
-
-std::pair<std::size_t, std::size_t> Gui::Render::getCameraTile() const
-{
-    return _camera.getTilePos();
-}
-
-Model Gui::Render::getTileModel() const
-{
-    return _tileModel;
 }

--- a/tests/gui/tests/GameDatas/TestPlayer.cpp
+++ b/tests/gui/tests/GameDatas/TestPlayer.cpp
@@ -5,6 +5,7 @@
 ** test player
 */
 
+#include "Config.hpp"
 #include "Assets.hpp"
 #include "GameDatas/Player.hpp"
 #include "CriterionHeaders.hpp"

--- a/tests/gui/tests/GameDatas/TestTeam.cpp
+++ b/tests/gui/tests/GameDatas/TestTeam.cpp
@@ -5,6 +5,7 @@
 ** TestTeam
 */
 
+#include "Config.hpp"
 #include "GameDatas/Team.hpp"
 #include "CriterionHeaders.hpp"
 

--- a/tests/gui/tests/GameDatas/TestTile.cpp
+++ b/tests/gui/tests/GameDatas/TestTile.cpp
@@ -5,6 +5,7 @@
 ** test tile
 */
 
+#include "Config.hpp"
 #include "Assets.hpp"
 #include "GameDatas/Tile.hpp"
 #include "CriterionHeaders.hpp"

--- a/tests/gui/tests/Render/TestDecoration.cpp
+++ b/tests/gui/tests/Render/TestDecoration.cpp
@@ -5,6 +5,7 @@
 ** TestDecoration
 */
 
+#include "Config.hpp"
 #include "Render/Decoration.hpp"
 #include "CriterionHeaders.hpp"
 
@@ -23,7 +24,7 @@ Test(Decoration, getGenerationItem, .timeout = 5)
 {
     Gui::Decoration deco;
 
-    deco.display(std::make_pair(2,2));
+    deco.display(std::make_pair(2,2), 1, std::make_pair(2,2));
     Map<bool> generation = deco.getGenerationItem(1);
 
     cr_assert(!generation[0][0]);


### PR DESCRIPTION
I added the chunk mechanism.
A chunk is considered as a simple tile, its content, and the things that are on it.
If the chunk is not in the render distance radius it's not displayed.

Here's a little preview of my work :wink: :


https://github.com/FppEpitech/Zappy/assets/114673563/fb1619a0-ebb5-4f4c-9f3a-c9122500ca28