### PR TITLE
Feat/implement first and second person player views zappy gui

### DIFF
--- a/gui/include/Config.hpp
+++ b/gui/include/Config.hpp
@@ -1,0 +1,14 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** Config
+*/
+
+#pragma once
+
+#define HIGH_CAMERA_INCREASE 0.1
+#define LOW_CAMERA_INCREASE 0.1
+
+#define PLAYER_SECOND_PERSON_FOV 4.0f
+#define PLAYER_THIRD_PERSON_FOV 5.0f

--- a/gui/include/Event/Event.hpp
+++ b/gui/include/Event/Event.hpp
@@ -7,13 +7,11 @@
 
 #pragma once
 
+#include "Config.hpp"
 #include "Render/Render.hpp"
 
 #include <functional>
 #include <unordered_map>
-
-#define HIGH_CAMERA_INCREASE 0.1
-#define LOW_CAMERA_INCREASE 0.1
 
 namespace Gui {
 

--- a/gui/include/Event/Event.hpp
+++ b/gui/include/Event/Event.hpp
@@ -82,7 +82,9 @@ class Gui::Event {
             {KEY_THREE, [this](){switchDisplayDebug();}},
             {KEY_F3, [this](){switchDisplayDebug();}},
             {KEY_SPACE, [this](){setFreeCam();}},
-            {KEY_R, [this](){switchTileHudToGame();}}
+            {KEY_R, [this](){switchTileHudToGame();}},
+            {KEY_F5, [this](){changeActualPlayerPov();}},
+            {KEY_APOSTROPHE, [this](){changeActualPlayerPov();}},
         };
 
         /**
@@ -148,11 +150,46 @@ class Gui::Event {
         void changePlayer(bool turn);
 
         /**
+         * @brief Change the player point of view.
+         *
+         * @param playerId Player id to select.
+         * @note The player point of view is the first person, second person and third person.
+        */
+        void changePlayerPOV(size_t playerId);
+
+        /**
+         * @brief Sets the Pov of the player.
+         *
+         * @param playerId Player id to select.
+        */
+        void setPlayerPov(size_t playerId);
+
+        /**
+         * @brief Change the actual player point of view.
+         *
+        */
+        void changeActualPlayerPov();
+
+        /**
+         * @brief Change the camera to the player.
+         *
+         * @param player Player to select.
+        */
+        void changePOVToFirstPerson(size_t id);
+
+        /**
+         * @brief Change the camera to the player.
+         *
+         * @param player Player to select.
+        */
+        void changePOVToSecondPerson(size_t id);
+
+        /**
          * @brief Change the camera to the player.
          *
          * @param player Player to select.
          */
-        void changeCameraToPlayer(size_t id);
+        void changePOVToThirdPerson(size_t id);
 
         /**
          * @brief Change the Hud of Tile to Game.

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -131,6 +131,15 @@ class Gui::Render {
         */
         Model getTileModel() const;
 
+        /**
+         * @brief Check if the camera is in player pov.
+         *
+         * @return true - Camera is in player pov.
+         * @return false - Camera is not in player pov.
+         * @note The player pov is the first person, second person and third person.
+         */
+        bool isCameraInPlayerPov() const;
+
     private:
 
         UserCamera                                  _camera;            // Camera of the scene.

--- a/gui/include/Render/UserCamera.hpp
+++ b/gui/include/Render/UserCamera.hpp
@@ -26,7 +26,9 @@ class Gui::UserCamera {
 
         enum CameraType {
             FREE,
-            POV_PLAYER,
+            FIRST_PERSON,
+            SECOND_PERSON,
+            THIRD_PERSON,
             FREE_TILE
         };
 
@@ -146,6 +148,15 @@ class Gui::UserCamera {
          * @return std::pair<std::size_t, std::size_t> - Position of the tile.
          */
         std::pair<std::size_t, std::size_t> getTilePos() const;
+
+        /**
+         * @brief Check if the camera is in player pov.
+         *
+         * @return true - Camera is in player pov.
+         * @return false - Camera is not in player pov.
+         * @note The player pov is the first person, second person and third person.
+        */
+        bool isPlayerPov() const;
 
     private:
 

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -65,7 +65,7 @@ void Gui::Event::switchDisplayDebug()
 
 void Gui::Event::setFreeCam()
 {
-    if (_render->getCameraType() == Gui::UserCamera::POV_PLAYER)
+    if (_render->getCameraType() != Gui::UserCamera::FREE && _render->getCameraType() != Gui::UserCamera::FREE_TILE)
         _render->setCameraType(Gui::UserCamera::FREE);
 }
 
@@ -80,7 +80,7 @@ void Gui::Event::handleLeftClick()
 
 void Gui::Event::handleRightClick()
 {
-    if (_render->getCameraType() == Gui::UserCamera::CameraType::POV_PLAYER)
+    if (_render.get()->isCameraInPlayerPov())
         changePlayer(false);
 }
 
@@ -100,7 +100,7 @@ void Gui::Event::selectPlayer()
                 }
             }
             if (team.isPlayerHit(player.getId(), *_render.get()->getCamera().get()))
-                this->changeCameraToPlayer(player.getId());
+                this->changePOVToFirstPerson(player.getId());
         }
     }
     EndMode3D();
@@ -166,10 +166,89 @@ void Gui::Event::changePlayer(bool turn)
             }
         }
     }
-    changeCameraToPlayer(playerId);
+    setPlayerPov(playerId);
 }
 
-void Gui::Event::changeCameraToPlayer(size_t playerId)
+void Gui::Event::changePlayerPOV(size_t playerId)
+{
+    if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::FIRST_PERSON)
+        changePOVToThirdPerson(playerId);
+    else if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::SECOND_PERSON)
+        changePOVToFirstPerson(playerId);
+    else if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::THIRD_PERSON)
+        changePOVToSecondPerson(playerId);
+}
+
+void Gui::Event::setPlayerPov(size_t playerId)
+{
+    if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::FIRST_PERSON)
+        changePOVToFirstPerson(playerId);
+    else if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::SECOND_PERSON)
+        changePOVToSecondPerson(playerId);
+    else if (_render.get()->getCameraType() == Gui::UserCamera::CameraType::THIRD_PERSON)
+        changePOVToThirdPerson(playerId);
+}
+
+void Gui::Event::changeActualPlayerPov()
+{
+    changePlayerPOV(_render.get()->getCameraPlayerPov());
+}
+
+void Gui::Event::changePOVToFirstPerson(size_t playerId)
+{
+    Gui::Player player = _gameData->getPlayer(playerId);
+    Vector3 playerPos;
+
+    try {
+        playerPos = _gameData.get()->getTeamById(player.getId()).getPlayerPositionIn3DSpace(playerId, _gameData.get()->getMap());
+    } catch (const Gui::Errors::GuiGameDataException &e) {
+        return;
+    }
+    _render.get()->getCamera().get()->target = playerPos;
+
+    if (player.getOrientation() == 1)
+        _render.get()->getCamera().get()->target.z = playerPos.z - 2.0f;
+    else if (player.getOrientation() == 3)
+        _render.get()->getCamera().get()->target.z = playerPos.z + 2.0f;
+    else if (player.getOrientation() == 2)
+        _render.get()->getCamera().get()->target.x = playerPos.x + 2.0f;
+    else if (player.getOrientation() == 4)
+        _render.get()->getCamera().get()->target.x = playerPos.x - 2.0f;
+    _render.get()->getCamera().get()->target.y = playerPos.y + PLAYER_HEIGHT;
+    _render.get()->getCamera().get()->position = playerPos;
+    _render.get()->getCamera().get()->position.y += PLAYER_HEIGHT;
+    _render.get()->setCameraType(Gui::UserCamera::CameraType::FIRST_PERSON);
+    _render.get()->setCameraPlayerPov(playerId);
+}
+
+void Gui::Event::changePOVToSecondPerson(size_t playerId)
+{
+    Gui::Player player = _gameData->getPlayer(playerId);
+    Vector3 playerPos;
+
+    try {
+        playerPos = _gameData.get()->getTeamById(player.getId()).getPlayerPositionIn3DSpace(playerId, _gameData.get()->getMap());
+    } catch (const Gui::Errors::GuiGameDataException &e) {
+        return;
+    }
+    _render.get()->getCamera().get()->position = playerPos;
+
+    if (player.getOrientation() == 1)
+        _render.get()->getCamera().get()->position.z = playerPos.z - PLAYER_SECOND_PERSON_FOV;
+    else if (player.getOrientation() == 3)
+        _render.get()->getCamera().get()->position.z = playerPos.z + PLAYER_SECOND_PERSON_FOV;
+    else if (player.getOrientation() == 2)
+        _render.get()->getCamera().get()->position.x = playerPos.x + PLAYER_SECOND_PERSON_FOV;
+    else if (player.getOrientation() == 4)
+        _render.get()->getCamera().get()->position.x = playerPos.x - PLAYER_SECOND_PERSON_FOV;
+    _render.get()->getCamera().get()->position.y = playerPos.y + PLAYER_HEIGHT;
+    _render.get()->getCamera().get()->target = playerPos;
+    _render.get()->getCamera().get()->target.y += PLAYER_HEIGHT;
+    _render.get()->setCameraType(Gui::UserCamera::CameraType::SECOND_PERSON);
+    _render.get()->setCameraPlayerPov(playerId);
+}
+
+void Gui::Event::changePOVToThirdPerson(size_t playerId)
 {
     Gui::Player player = _gameData->getPlayer(playerId);
     Vector3 playerPos;
@@ -183,16 +262,16 @@ void Gui::Event::changeCameraToPlayer(size_t playerId)
     _render.get()->getCamera().get()->position.y = playerPos.y + 4.0f;
 
     if (player.getOrientation() == 1)
-        _render.get()->getCamera().get()->position.z = playerPos.z + 5.0f;
+        _render.get()->getCamera().get()->position.z = playerPos.z + PLAYER_THIRD_PERSON_FOV;
     else if (player.getOrientation() == 3)
-        _render.get()->getCamera().get()->position.z = playerPos.z - 5.0f;
+        _render.get()->getCamera().get()->position.z = playerPos.z - PLAYER_THIRD_PERSON_FOV;
     else if (player.getOrientation() == 2)
-        _render.get()->getCamera().get()->position.x = playerPos.x - 5.0f;
+        _render.get()->getCamera().get()->position.x = playerPos.x - PLAYER_THIRD_PERSON_FOV;
     else if (player.getOrientation() == 4)
-        _render.get()->getCamera().get()->position.x = playerPos.x + 5.0f;
+        _render.get()->getCamera().get()->position.x = playerPos.x + PLAYER_THIRD_PERSON_FOV;
     _render.get()->getCamera().get()->target = playerPos;
     _render.get()->getCamera().get()->target.y += PLAYER_HEIGHT;
-    _render.get()->setCameraType(Gui::UserCamera::POV_PLAYER);
+    _render.get()->setCameraType(Gui::UserCamera::CameraType::THIRD_PERSON);
     _render.get()->setCameraPlayerPov(playerId);
 }
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -51,7 +51,7 @@ bool Gui::Render::isOpen()
 
 void Gui::Render::draw()
 {
-    if (_camera.getType() != Gui::UserCamera::POV_PLAYER)
+    if (!_camera.isPlayerPov())
         UpdateCamera(_camera.getCamera().get(), CAMERA_FIRST_PERSON);
 
     BeginDrawing();
@@ -85,6 +85,11 @@ bool Gui::Render::getIsDebug()
     return _isDebug;
 }
 
+bool Gui::Render::isCameraInPlayerPov() const
+{
+    return _camera.isPlayerPov();
+}
+
 void Gui::Render::displayDebug()
 {
     if (_isDebug) {
@@ -99,6 +104,7 @@ void Gui::Render::displayDebug()
             std::to_string(_camera.getCamera()->target.y) + " / " +
             std::to_string(_camera.getCamera()->target.z)
             ).c_str(), 10, 50, 20, LIME);
+        DrawText(("CAMERA TYPE: " + std::to_string(_camera.getType())).c_str(), 10, 70, 20, LIME);
     }
 }
 
@@ -108,6 +114,8 @@ void Gui::Render::displayPlayers()
         for (auto &player : team.getPlayers()) {
             if (_gameData.get()->getMap().size() == 0 || _gameData.get()->getMap()[player.getPosition().first].size() == 0)
                 return;
+            if (_camera.getPlayerId() == player.getId() && _camera.getType() == Gui::UserCamera::FIRST_PERSON)
+                continue;
 
             float rotation = player.getRotationFromOrientation();
 
@@ -243,7 +251,7 @@ void Gui::Render::displayDeraumere(Tile tile) const
 void Gui::Render::displayHUD(void)
 {
     for (auto &hud : _hudList) {
-        if (hud->getType() == Gui::HudPlayer::POV_PLAYER && _camera.getType() == Gui::UserCamera::POV_PLAYER) {
+        if (hud->getType() == Gui::HudPlayer::POV_PLAYER && _camera.isPlayerPov()) {
             hud->setPlayer(std::make_shared<Player>(_gameData->getPlayer(_camera.getPlayerId())));
             hud->display();
         }
@@ -258,7 +266,7 @@ void Gui::Render::displayHUD(void)
 
 void Gui::Render::displayCursor()
 {
-    if (_camera.getType() != Gui::UserCamera::POV_PLAYER)
+    if (_camera.getType() != Gui::UserCamera::CameraType::SECOND_PERSON && _camera.getType() != Gui::UserCamera::CameraType::THIRD_PERSON)
         DrawTexture(_cursorTexture, GetScreenWidth() / 2 - _cursorTexture.width / 2, GetScreenHeight() / 2 - _cursorTexture.height / 2, BLACK);
 }
 

--- a/gui/src/Render/UserCamera.cpp
+++ b/gui/src/Render/UserCamera.cpp
@@ -92,3 +92,8 @@ std::pair<std::size_t, std::size_t> Gui::UserCamera::getTilePos() const
 {
     return _tilePos;
 }
+
+bool Gui::UserCamera::isPlayerPov() const
+{
+    return _type == FIRST_PERSON || _type == SECOND_PERSON || _type == THIRD_PERSON;
+}


### PR DESCRIPTION
I added the First and Second person.

> [!Note]
> You can swap POV by pressing F5 or Apostrophe `'`

> [!Note]
> When changing player POV (from a player to another), the POV type doesn't change, if needed, tell me :+1: 

Here's a little example:


https://github.com/FppEpitech/Zappy/assets/114673563/460ebaeb-9d65-45c7-8738-fa5ee6e7dfcc