### PR TITLE
feat: make install-deps in doc/

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,4 +29,7 @@ server-doc:
 	@mv doxygen/latex/refman.pdf ./server-doc/doxygen-auto-doc.pdf
 	@cp doxygen/html/* ./server-doc/website-doc -r
 
+install-deps:
+	sudo dnf install doxygen-latex
+
 .PHONY: ai-doc gui-doc server-doc doxygen


### PR DESCRIPTION
You can now execute "make install-deps" in doc/, installing all requirements to generate the documentation with doxygen, thanks to the command "make doc" in root folder.