### PR TITLE
feat: Display player Broadcast above player level

### DIFF
--- a/gui/include/Assets.hpp
+++ b/gui/include/Assets.hpp
@@ -90,3 +90,5 @@
 #define POS_TREE                    (Vector3){2, -0.3, 2}
 #define POS_LANTERN                 (Vector3){1, -0.3, 2}
 #define POS_Y_DELIMITATION          -0.27f
+
+#define PLAYER_TEXT_SIZE            40

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -255,6 +255,14 @@ class Gui::Render {
         void displayPlayerLevel(Team &team, Player &player);
 
         /**
+         * @brief Display player broadcast.
+         *
+         * @param team Team for the player 3d position.
+         * @param player Player to display broadcast.
+         */
+        void displayPlayerBroadcast(Team &team, Player &player);
+
+        /**
          * @brief Display the map.
          *
          */

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -201,6 +201,8 @@ void Gui::Render::displayPlayers()
                 DrawModelEx(team.getPlayerModel(), team.getPlayerPositionIn3DSpace(player.getId(), _gameData.get()->getMap()), ROTATION_AXIS_PLAYER, rotation, SCALE_PLAYER, team.getPlayerColor());
 
             displayPlayerLevel(team, player);
+            if (player.getState() == Gui::Player::BROADCAST)
+                displayPlayerBroadcast(team, player);
 
             if (_isDebug) {
                 std::vector<BoundingBox> bboxes = team.getPlayerBoundingBoxes(player.getPosition(), player.getOrientation(), player.getCenterPosition());
@@ -218,8 +220,21 @@ void Gui::Render::displayPlayerLevel(Gui::Team &team, Gui::Player &player)
     EndMode3D();
 
     Vector3 playerPos = team.getPlayerPositionIn3DSpace(player.getId(), _gameData.get()->getMap());
-    Vector2 playerScreenPosition = GetWorldToScreen((Vector3){playerPos.x, playerPos.y + PLAYER_HEIGHT + 0.5F, playerPos.z}, *_camera.getCamera().get());
+    Vector2 playerScreenPosition = GetWorldToScreen((Vector3){playerPos.x, playerPos.y + PLAYER_HEIGHT + 0.5f, playerPos.z}, *_camera.getCamera().get());
     std::string countStr = "Lvl: " + std::to_string(player.getLevel());
+
+    DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), 40)/2, (int)playerScreenPosition.y , 40, WHITE);
+
+    BeginMode3D(*_camera.getCamera());
+}
+
+void Gui::Render::displayPlayerBroadcast(Gui::Team &team, Gui::Player &player)
+{
+    EndMode3D();
+
+    Vector3 playerPos = team.getPlayerPositionIn3DSpace(player.getId(), _gameData.get()->getMap());
+    Vector2 playerScreenPosition = GetWorldToScreen((Vector3){playerPos.x, playerPos.y + PLAYER_HEIGHT + 0.7f, playerPos.z}, *_camera.getCamera().get());
+    std::string countStr = player.getBroadcast();
 
     DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), 40)/2, (int)playerScreenPosition.y , 40, WHITE);
 

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -223,7 +223,7 @@ void Gui::Render::displayPlayerLevel(Gui::Team &team, Gui::Player &player)
     Vector2 playerScreenPosition = GetWorldToScreen((Vector3){playerPos.x, playerPos.y + PLAYER_HEIGHT + 0.5f, playerPos.z}, *_camera.getCamera().get());
     std::string countStr = "Lvl: " + std::to_string(player.getLevel());
 
-    DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), 40)/2, (int)playerScreenPosition.y , 40, WHITE);
+    DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), PLAYER_TEXT_SIZE)/2, (int)playerScreenPosition.y , PLAYER_TEXT_SIZE, WHITE);
 
     BeginMode3D(*_camera.getCamera());
 }
@@ -236,7 +236,7 @@ void Gui::Render::displayPlayerBroadcast(Gui::Team &team, Gui::Player &player)
     Vector2 playerScreenPosition = GetWorldToScreen((Vector3){playerPos.x, playerPos.y + PLAYER_HEIGHT + 0.7f, playerPos.z}, *_camera.getCamera().get());
     std::string countStr = player.getBroadcast();
 
-    DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), 40)/2, (int)playerScreenPosition.y , 40, WHITE);
+    DrawText(countStr.c_str(), (int)playerScreenPosition.x - MeasureText(countStr.c_str(), PLAYER_TEXT_SIZE)/2, (int)playerScreenPosition.y , PLAYER_TEXT_SIZE, WHITE);
 
     BeginMode3D(*_camera.getCamera());
 }


### PR DESCRIPTION
I added the broadcast display above the player level.

Here's a little example:

![image](https://github.com/FppEpitech/Zappy/assets/114673563/44ad98e2-c522-4584-a241-e22a36724eac)
