### PR TITLE
FIX Warning: deprecated flag use in test of c

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install_dependencies
         run: |
+            sudo apt-get install lcov gcovr -y
             make install-deps-ci -C gui
             make install-deps -C ai
       - name: run_tests

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -92,9 +92,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: install_dependencies
         run: |
-            sudo dnf install lcov gcovr -y
             make install-deps-ci -C gui
             make install-deps -C ai
+            gcovr --version
       - name: run_tests
         run: make tests_run
         timeout-minutes: 5

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install_dependencies
         run: |
-            sudo apt-get install lcov gcovr -y
+            sudo dnf install lcov gcovr -y
             make install-deps-ci -C gui
             make install-deps -C ai
       - name: run_tests

--- a/server/Makefile
+++ b/server/Makefile
@@ -201,4 +201,4 @@ tests_run: fclean
 	@$(CC) -o $(TEST_NAME) $(OBJ) $(TEST_OBJ) $(TEST_FLAGS) $(INCLUDE)
 	./$(TEST_NAME)
 	gcovr --exclude tests/
-	gcovr --exclude tests/ --branches
+	gcovr --exclude tests/ --txt-metric branch


### PR DESCRIPTION
I replace the --branch flag by --txt-metric branch in the tests_run rule of sever Makefile for avoid a warning about the depreciation of the --branch flag.