### PR TITLE
Feat/create interface to test network zappy gui

### DIFF
--- a/gui/Makefile
+++ b/gui/Makefile
@@ -10,6 +10,7 @@ MAIN 		=	src/main.cpp
 
 SRC			=	src/Error/Error.cpp \
 				\
+				src/Network/ANetwork.cpp \
 				src/Network/Network.cpp \
 				\
 				src/Engine/Engine.cpp \

--- a/gui/include/Engine/Engine.hpp
+++ b/gui/include/Engine/Engine.hpp
@@ -51,7 +51,7 @@ class Gui::Engine {
     private:
 
         ServerParser                _parser;        // Parser class for server's command.
-        std::shared_ptr<INetwork>    _network;       // Network class to connect to the server.
+        std::shared_ptr<INetwork>   _network;       // Network class to connect to the server.
         std::shared_ptr<Render>     _render;        // Render class to draw the scene.
         Event                       _event;         // Event class to listen the user's inputs.
         std::shared_ptr<GameData>   _gameData;      // GameData class to store the game's data.

--- a/gui/include/Engine/Engine.hpp
+++ b/gui/include/Engine/Engine.hpp
@@ -9,7 +9,7 @@
 
 #include "Event/Event.hpp"
 #include "Render/Render.hpp"
-#include "Network/Network.hpp"
+#include "Network/INetwork.hpp"
 #include "GameDatas/GameData.hpp"
 #include "Parsing/ServerParser.hpp"
 #include "GUIUpdater/GUIUpdater.hpp"
@@ -34,7 +34,7 @@ class Gui::Engine {
          *
          * @param network Network class.
          */
-        Engine(std::shared_ptr<Network> network);
+        Engine(std::shared_ptr<INetwork> network);
 
         /**
          * @brief Destroy the Engine object.
@@ -51,7 +51,7 @@ class Gui::Engine {
     private:
 
         ServerParser                _parser;        // Parser class for server's command.
-        std::shared_ptr<Network>    _network;       // Network class to connect to the server.
+        std::shared_ptr<INetwork>    _network;       // Network class to connect to the server.
         std::shared_ptr<Render>     _render;        // Render class to draw the scene.
         Event                       _event;         // Event class to listen the user's inputs.
         std::shared_ptr<GameData>   _gameData;      // GameData class to store the game's data.

--- a/gui/include/GUIUpdater/GUIUpdater.hpp
+++ b/gui/include/GUIUpdater/GUIUpdater.hpp
@@ -34,7 +34,7 @@ class Gui::GUIUpdater {
          * @param gameData The GUI GameData to update.
          * @param network The network to send commands to the server.
         */
-        GUIUpdater(std::shared_ptr<GameData> gameData, std::shared_ptr<Network> network);
+        GUIUpdater(std::shared_ptr<GameData> gameData, std::shared_ptr<INetwork> network);
 
         /**
          * @brief Destroy the GUIUpdater object.
@@ -52,7 +52,7 @@ class Gui::GUIUpdater {
     private:
 
         std::shared_ptr<GameData>       _gameData; // The GUI GameData to update.
-        std::shared_ptr<Network>        _network; // The network to send commands to the server.
+        std::shared_ptr<INetwork>        _network; // The network to send commands to the server.
         size_t                          _colorIndex; // The index of the color to use for the team.
 
         std::unordered_map<std::string, std::function<void(std::vector<std::string>)>> _updateMap =

--- a/gui/include/GUIUpdater/GUIUpdater.hpp
+++ b/gui/include/GUIUpdater/GUIUpdater.hpp
@@ -52,7 +52,7 @@ class Gui::GUIUpdater {
     private:
 
         std::shared_ptr<GameData>       _gameData; // The GUI GameData to update.
-        std::shared_ptr<INetwork>        _network; // The network to send commands to the server.
+        std::shared_ptr<INetwork>       _network; // The network to send commands to the server.
         size_t                          _colorIndex; // The index of the color to use for the team.
 
         std::unordered_map<std::string, std::function<void(std::vector<std::string>)>> _updateMap =

--- a/gui/include/Network/ANetwork.hpp
+++ b/gui/include/Network/ANetwork.hpp
@@ -1,0 +1,94 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** ANetwork
+*/
+
+#pragma once
+
+#include "Network/INetwork.hpp"
+
+#define MIN_PORT 1
+#define MAX_PORT 65535
+
+namespace Gui {
+
+    /**
+     * @brief Abstract class for the Network class.
+     *
+     */
+    class ANetwork;
+};
+
+class Gui::ANetwork : public Gui::INetwork {
+    public:
+
+        /**
+         * @brief Construct a new ANetwork object.
+         *
+         * @param port Port of the server.
+         * @param hostName Host of the server.
+         */
+        ANetwork(int port, const std::string &hostName);
+
+        /**
+         * @brief Destroy the ANetwork object.
+         *
+         */
+        ~ANetwork() = default;
+
+        /**
+         * @brief Set the port object.
+         *
+         * @param port Port of the server.
+         * @throw NetworkException If the port is not in range 1 to 65535.
+         */
+        void setPort(int port) final;
+
+        /**
+         * @brief Set the host name object.
+         *
+         * @param hostName Host of the server.
+         */
+        void setHostName(const std::string &hostName) final;
+
+        /**
+         * @brief Get the host name object.
+         *
+         * @return std::string Host of the server.
+         */
+        int getPort() const final;
+
+        /**
+         * @brief Get the host name object.
+         *
+         * @return std::string Host of the server.
+         */
+        std::string getHostName() const final;
+
+        /**
+         * @brief Connect to the server.
+         *
+         * @throw NetworkException If the connection failed.
+         */
+        virtual void connectToServer() = 0;
+
+        /**
+         * @brief Listen the server and return it message.
+         *
+         * @return std::string - Message of the server.
+         */
+        virtual const std::string listenServer() = 0;
+
+        /**
+         * @brief Send a message to the Server.
+         *
+         * @param message Message to send to the server.
+         */
+        virtual void sendMessageServer(const std::string& message) = 0;
+
+    protected:
+        int             _port;          // Port of the server.
+        std::string     _hostName;      // Host name of the server.
+};

--- a/gui/include/Network/INetwork.hpp
+++ b/gui/include/Network/INetwork.hpp
@@ -1,0 +1,82 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** INetwork
+*/
+
+#pragma once
+
+#include "Error/Error.hpp"
+
+#include <string>
+
+namespace Gui {
+
+    /**
+     * @brief Interface for the Network class.
+     *
+     */
+    class INetwork;
+};
+
+class Gui::INetwork {
+
+    public:
+
+        /**
+         * @brief Destroy the INetwork object.
+         *
+         */
+        virtual ~INetwork() = default;
+
+        /**
+         * @brief Set the port object.
+         *
+         * @param port Port of the server.
+         * @throw NetworkException If the port is not in range 1 to 65535.
+         */
+        virtual void setPort(int port) = 0;
+
+        /**
+         * @brief Set the host name object.
+         *
+         * @param hostName Host of the server.
+         */
+        virtual void setHostName(const std::string &hostName) = 0;
+
+        /**
+         * @brief Get the host name object.
+         *
+         * @return std::string Host of the server.
+         */
+        virtual int getPort() const = 0;
+
+        /**
+         * @brief Get the host name object.
+         *
+         * @return std::string Host of the server.
+         */
+        virtual std::string getHostName() const = 0;
+
+        /**
+         * @brief Connect to the server.
+         *
+         * @throw Error::NetworkError If the connection failed.
+         */
+        virtual void connectToServer() = 0;
+
+        /**
+         * @brief Listen to the server.
+         *
+         * @return std::string Message from the server.
+         */
+        virtual const std::string listenServer() = 0;
+
+        /**
+         * @brief Send a message to the server.
+         *
+         * @param message Message to send.
+         */
+        virtual void sendMessageServer(const std::string &message) = 0;
+};

--- a/gui/include/Network/Network.hpp
+++ b/gui/include/Network/Network.hpp
@@ -7,15 +7,11 @@
 
 #pragma once
 
-#include "Error/Error.hpp"
+#include "Network/ANetwork.hpp"
 
-#include <string>
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-
-#define MAX_PORT 65535
-#define MIN_PORT 1
 
 namespace Gui {
 
@@ -26,7 +22,7 @@ namespace Gui {
     class Network;
 };
 
-class Gui::Network {
+class Gui::Network : public Gui::ANetwork {
 
     public:
 
@@ -36,45 +32,12 @@ class Gui::Network {
          * @param port Port of the server.
          * @param hostName Host of the server.
          */
-        Network(int port, const std::string& hostName);
-
-        /**
-         * @brief Destroy the Network object.
-         *
-         */
-        ~Network() = default;
-
-        /**
-         * @brief Set the port object.
-         *
-         * @param port Port of the server.
-         */
-        void setPort(int port);
-
-        /**
-         * @brief Set the host name object.
-         *
-         * @param hostName Host of the server.
-         */
-        void setHostName(const std::string& hostName);
-
-        /**
-         * @brief Get the port object.
-         *
-         * @return const int - Port of the server.
-         */
-        int getPort() const;
-
-        /**
-         * @brief Get the host name object.
-         *
-         * @return const std::string - Host name of the server.
-         */
-        std::string getHostName() const;
+        Network(int port, const std::string &hostName);
 
         /**
          * @brief Connect the Gui network with the server.
          *
+         * @throw NetworkException If the connection failed.
          */
         void connectToServer();
 
@@ -107,8 +70,6 @@ class Gui::Network {
          */
         const std::string readInfoServer();
 
-        int             _port;          // server port
-        std::string     _hostName;      // server hostname
         int             _serverFd;      // server file descriptor
         fd_set          _writeFd;       // file descriptor for write access
         fd_set          _readFd;        // file descriptor for read access

--- a/gui/src/Engine/Engine.cpp
+++ b/gui/src/Engine/Engine.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <sstream>
 
-Gui::Engine::Engine(std::shared_ptr<Network> network) : _network(network), _gameData(std::make_shared<GameData>()), _guiUpdater(_gameData, _network)
+Gui::Engine::Engine(std::shared_ptr<INetwork> network) : _network(network), _gameData(std::make_shared<GameData>()), _guiUpdater(_gameData, _network)
 {
     _render = std::make_shared<Render>(_gameData);
     _event.setRender(_render);

--- a/gui/src/GUIUpdater/GUIUpdater.cpp
+++ b/gui/src/GUIUpdater/GUIUpdater.cpp
@@ -10,7 +10,7 @@
 #include "Error/Error.hpp"
 #include "GUIUpdater/GUIUpdater.hpp"
 
-Gui::GUIUpdater::GUIUpdater(std::shared_ptr<GameData> gameData, std::shared_ptr<Network> network) : _gameData(gameData), _network(network), _colorIndex(0) {}
+Gui::GUIUpdater::GUIUpdater(std::shared_ptr<GameData> gameData, std::shared_ptr<INetwork> network) : _gameData(gameData), _network(network), _colorIndex(0) {}
 
 void Gui::GUIUpdater::update(const std::string &command, const std::vector<std::string> &data)
 {
@@ -332,7 +332,7 @@ void Gui::GUIUpdater::updatePlayerEndIncantation(const std::vector<std::string> 
                 player.setState(Gui::Player::PlayerState::IDLE);
                 for (size_t i = 0; i < team.getPlayers().size(); i++) {
                     if (team.getPlayers()[i].getPosition().first == player.getPosition().first && team.getPlayers()[i].getPosition().second == player.getPosition().second)
-                        _network->sendMessageServer("plv " + std::to_string(player.getId()) + "\n");
+                        _network.get()->sendMessageServer("plv " + std::to_string(player.getId()) + "\n");
                 }
             }
         }
@@ -406,7 +406,7 @@ void Gui::GUIUpdater::updatePlayerRessourceCollecting(const std::vector<std::str
         for (auto &player : team.getPlayers()) {
             if (player.getId() == args[0]) {
                 player.setState(Gui::Player::PlayerState::COLLECT);
-                _network->sendMessageServer("pin " + std::to_string(player.getId()) + "\n");
+                _network.get()->sendMessageServer("pin " + std::to_string(player.getId()) + "\n");
             }
         }
     }

--- a/gui/src/Network/ANetwork.cpp
+++ b/gui/src/Network/ANetwork.cpp
@@ -9,8 +9,8 @@
 
 Gui::ANetwork::ANetwork(int port, const std::string &hostName)
 {
-    this->_port = port;
-    this->_hostName = hostName;
+    this->setPort(port);
+    this->setHostName(hostName);
 }
 
 void Gui::ANetwork::setPort(int port)

--- a/gui/src/Network/ANetwork.cpp
+++ b/gui/src/Network/ANetwork.cpp
@@ -1,0 +1,36 @@
+/*
+** EPITECH PROJECT, 2024
+** Zappy
+** File description:
+** ANetwork
+*/
+
+#include "Network/ANetwork.hpp"
+
+Gui::ANetwork::ANetwork(int port, const std::string &hostName)
+{
+    this->_port = port;
+    this->_hostName = hostName;
+}
+
+void Gui::ANetwork::setPort(int port)
+{
+    if (port < MIN_PORT || port > MAX_PORT)
+        throw Errors::NetworkException("Port should be in range 1 to 65535.");
+    _port = port;
+}
+
+void Gui::ANetwork::setHostName(const std::string &hostName)
+{
+    this->_hostName = hostName;
+}
+
+int Gui::ANetwork::getPort() const
+{
+    return this->_port;
+}
+
+std::string Gui::ANetwork::getHostName() const
+{
+    return this->_hostName;
+}

--- a/gui/src/Network/Network.cpp
+++ b/gui/src/Network/Network.cpp
@@ -11,33 +11,9 @@
 #include <unistd.h>
 #include <iostream>
 
-Gui::Network::Network(int port, const std::string& hostName)
+Gui::Network::Network(int port, const std::string &hostName) : ANetwork(port, hostName)
 {
-    setPort(port);
-    setHostName(hostName);
     _isConnected = false;
-}
-
-void Gui::Network::setPort(int port)
-{
-    if (port < MIN_PORT || port > MAX_PORT)
-        throw Errors::NetworkException("Port should be in range 1 to 65535.");
-    _port = port;
-}
-
-void Gui::Network::setHostName(const std::string& hostName)
-{
-    _hostName = hostName;
-}
-
-int Gui::Network::getPort() const
-{
-    return _port;
-}
-
-std::string Gui::Network::getHostName() const
-{
-    return _hostName;
 }
 
 void Gui::Network::connectToServer()
@@ -97,7 +73,7 @@ const std::string Gui::Network::readInfoServer()
     return data;
 }
 
-void Gui::Network::sendMessageServer(const std::string& message)
+void Gui::Network::sendMessageServer(const std::string &message)
 {
     if (FD_ISSET(_serverFd, &_writeFd)) {
         write(_serverFd, message.c_str(), message.length());

--- a/tests/gui/tests/GUIUpdater/TestGUIUpdater.cpp
+++ b/tests/gui/tests/GUIUpdater/TestGUIUpdater.cpp
@@ -11,7 +11,7 @@
 Test(GUIUpdater, constructor, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_not_null(&guiUpdater);
@@ -20,7 +20,7 @@ Test(GUIUpdater, constructor, .timeout = 5)
 Test(GUIUpdater, update, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("test", {"test"});
@@ -30,7 +30,7 @@ Test(GUIUpdater, update, .timeout = 5)
 Test(GUIUpdater, updateMapSize, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("msz", {"10", "10"});
@@ -41,7 +41,7 @@ Test(GUIUpdater, updateMapSize, .timeout = 5)
 Test(GUIUpdater, updateMapSizeError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("msz", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -50,7 +50,7 @@ Test(GUIUpdater, updateMapSizeError, .timeout = 5)
 Test(GUIUpdater, updateMapSizeErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("msz", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -59,7 +59,7 @@ Test(GUIUpdater, updateMapSizeErrorValue, .timeout = 5)
 Test(GUIUpdater, updateMapSizeInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     cr_assert_throw(guiUpdater.update("msz", {}), Gui::Errors::GuiUpdaterException);
 }
@@ -67,7 +67,7 @@ Test(GUIUpdater, updateMapSizeInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updateMapContent, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData.get()->setMapSize(10, 10);
@@ -84,7 +84,7 @@ Test(GUIUpdater, updateMapContent, .timeout = 5)
 Test(GUIUpdater, updateMapContentError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("bct", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -94,7 +94,7 @@ Test(GUIUpdater, updateMapContentErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("bct", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -104,7 +104,7 @@ Test(GUIUpdater, updateMapContentInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("bct", {}), Gui::Errors::GuiUpdaterException);
@@ -114,7 +114,7 @@ Test(GUIUpdater, updateMapContentErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(2, 2);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("bct", {"5", "5", "2", "3", "4", "5", "6", "7", "8"}),Gui::Errors::GuiUpdaterException);
@@ -123,7 +123,7 @@ Test(GUIUpdater, updateMapContentErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateTeamNames, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("tna", {"TEAM1"});
@@ -133,7 +133,7 @@ Test(GUIUpdater, updateTeamNames, .timeout = 5)
 Test(GUIUpdater, updateTeamNamesError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("tna", {"test"});
@@ -143,7 +143,7 @@ Test(GUIUpdater, updateTeamNamesError, .timeout = 5)
 Test(GUIUpdater, updateTeamNamesInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     cr_assert_throw(guiUpdater.update("tna", {}), Gui::Errors::GuiUpdaterException);
 }
@@ -151,7 +151,7 @@ Test(GUIUpdater, updateTeamNamesInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updateTeamMember, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -168,7 +168,7 @@ Test(GUIUpdater, updateTeamMemberErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pnw", {"1", "-1", "1", "1", "1", "TEAM1"}), Gui::Errors::GuiUpdaterException);
@@ -179,7 +179,7 @@ Test(GUIUpdater, updateTeamMemberErrorValue, .timeout = 5)
 Test(GUIUpdater, updateTeamMemberError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pnw", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -188,7 +188,7 @@ Test(GUIUpdater, updateTeamMemberError, .timeout = 5)
 Test(GUIUpdater, updateTeamMemberInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     cr_assert_throw(guiUpdater.update("pnw", {"1", "1", "1", "1", "1", "TEAM", "1"}), Gui::Errors::GuiUpdaterException);
 }
@@ -197,7 +197,7 @@ Test(GUIUpdater, updateTeamMemberErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pnw", {"1", "1", "1", "0", "1", "1"}), Gui::Errors::GuiUpdaterException);
@@ -207,7 +207,7 @@ Test(GUIUpdater, updateTeamMemberErrorValue3, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pnw", {"1", "1", "1", "2", "0", "1"}), Gui::Errors::GuiUpdaterException);
@@ -216,7 +216,7 @@ Test(GUIUpdater, updateTeamMemberErrorValue3, .timeout = 5)
 Test(GUIUpdater, updatePlayerPosition, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -230,7 +230,7 @@ Test(GUIUpdater, updatePlayerPosition, .timeout = 5)
 Test(GUIUpdater, updatePlayerPositionErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ppo", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -239,7 +239,7 @@ Test(GUIUpdater, updatePlayerPositionErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerPositionErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ppo", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -249,7 +249,7 @@ Test(GUIUpdater, updatePlayerPositionInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ppo", {}), Gui::Errors::GuiUpdaterException);
@@ -258,7 +258,7 @@ Test(GUIUpdater, updatePlayerPositionInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updatePlayerPositionOrientationErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ppo", {"1", "1", "0", "50"}), Gui::Errors::GuiUpdaterException);
@@ -268,7 +268,7 @@ Test(GUIUpdater, updatePlayerPositionOrientationInvalidNumberOfArguments, .timeo
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ppo", {"1", "1", "1"}), Gui::Errors::GuiUpdaterException);
@@ -278,7 +278,7 @@ Test(GUIUpdater, updatePlayerPositionOrientationInvalidNumberOfArguments, .timeo
 Test(GUIUpdater, updatePlayerLevel, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -291,7 +291,7 @@ Test(GUIUpdater, updatePlayerLevel, .timeout = 5)
 Test(GUIUpdater, updatePlayerLevelErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("plv", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -300,7 +300,7 @@ Test(GUIUpdater, updatePlayerLevelErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerLevelErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("plv", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -309,7 +309,7 @@ Test(GUIUpdater, updatePlayerLevelErrorValue2, .timeout = 5)
 Test(GUIUpdater, updatePlayerLevelErrorValue3, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("plv", {"0", "50"}), Gui::Errors::GuiUpdaterException);
@@ -319,7 +319,7 @@ Test(GUIUpdater, updatePlayerLevelInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("plv", {}), Gui::Errors::GuiUpdaterException);
@@ -328,7 +328,7 @@ Test(GUIUpdater, updatePlayerLevelInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updatePlayerInventory, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -347,7 +347,7 @@ Test(GUIUpdater, updatePlayerInventory, .timeout = 5)
 Test(GUIUpdater, updatePlayerInventoryError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pin", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -356,7 +356,7 @@ Test(GUIUpdater, updatePlayerInventoryError, .timeout = 5)
 Test(GUIUpdater, updatePlayerInventoryErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pin", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -366,7 +366,7 @@ Test(GUIUpdater, updatePlayerInventoryInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pin", {"1"}), Gui::Errors::GuiUpdaterException);
@@ -375,7 +375,7 @@ Test(GUIUpdater, updatePlayerInventoryInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updatePlayerExpulsion, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -389,7 +389,7 @@ Test(GUIUpdater, updatePlayerExpulsion, .timeout = 5)
 Test(GUIUpdater, updatePlayerExpulsionError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pex", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -398,7 +398,7 @@ Test(GUIUpdater, updatePlayerExpulsionError, .timeout = 5)
 Test(GUIUpdater, updatePlayerExpulsionErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pex", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -407,7 +407,7 @@ Test(GUIUpdater, updatePlayerExpulsionErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerBroadcast, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
@@ -421,7 +421,7 @@ Test(GUIUpdater, updatePlayerBroadcast, .timeout = 5)
 Test(GUIUpdater, updatePlayerBroadcastError, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pbc", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -430,7 +430,7 @@ Test(GUIUpdater, updatePlayerBroadcastError, .timeout = 5)
 Test(GUIUpdater, updatePlayerBroadcastErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pbc", {"-5"}), Gui::Errors::GuiUpdaterException);
@@ -439,7 +439,7 @@ Test(GUIUpdater, updatePlayerBroadcastErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerStartIncantation, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -451,7 +451,7 @@ Test(GUIUpdater, updatePlayerStartIncantation, .timeout = 5)
 Test(GUIUpdater, updatePlayerStartIncantationErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -462,7 +462,7 @@ Test(GUIUpdater, updatePlayerStartIncantationErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerStartIncantationErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -474,7 +474,7 @@ Test(GUIUpdater, updatePlayerEndIncantationInvalidNumberOfArguments, .timeout = 
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pie", {}), Gui::Errors::GuiUpdaterException);
@@ -484,7 +484,7 @@ Test(GUIUpdater, updatePlayerEndIncantationInvalidNumberOfArguments, .timeout = 
 Test(GUIUpdater, updatePlayerEndIncantation, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -496,7 +496,7 @@ Test(GUIUpdater, updatePlayerEndIncantation, .timeout = 5)
 Test(GUIUpdater, updatePlayerEndIncantationErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -507,7 +507,7 @@ Test(GUIUpdater, updatePlayerEndIncantationErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerEndIncantationErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -519,7 +519,7 @@ Test(GUIUpdater, updatePlayerStartIncantationInvalidNumberOfArguments, .timeout 
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pic", {}), Gui::Errors::GuiUpdaterException);
@@ -528,7 +528,7 @@ Test(GUIUpdater, updatePlayerStartIncantationInvalidNumberOfArguments, .timeout 
 Test(GUIUpdater, updatePlayerEggLaying, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -540,7 +540,7 @@ Test(GUIUpdater, updatePlayerEggLaying, .timeout = 5)
 Test(GUIUpdater, updatePlayerEggLayingErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -551,7 +551,7 @@ Test(GUIUpdater, updatePlayerEggLayingErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerEggLayingErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -562,7 +562,7 @@ Test(GUIUpdater, updatePlayerEggLayingErrorValue2, .timeout = 5)
 Test(GUIUpdater, updatePlayerRessourceDropping, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -574,7 +574,7 @@ Test(GUIUpdater, updatePlayerRessourceDropping, .timeout = 5)
 Test(GUIUpdater, updatePlayerRessourceDroppingErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -585,7 +585,7 @@ Test(GUIUpdater, updatePlayerRessourceDroppingErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerRessourceDroppingErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -597,7 +597,7 @@ Test(GUIUpdater, updatePlayerRessourceDroppingInvalidNumberOfArguments, .timeout
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pdr", {}), Gui::Errors::GuiUpdaterException);
@@ -606,7 +606,7 @@ Test(GUIUpdater, updatePlayerRessourceDroppingInvalidNumberOfArguments, .timeout
 Test(GUIUpdater, updateRessourceCollecting, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -618,7 +618,7 @@ Test(GUIUpdater, updateRessourceCollecting, .timeout = 5)
 Test(GUIUpdater, updateRessourceCollectingErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -629,7 +629,7 @@ Test(GUIUpdater, updateRessourceCollectingErrorValue, .timeout = 5)
 Test(GUIUpdater, updateRessourceCollectingErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -641,7 +641,7 @@ Test(GUIUpdater, updateRessourceCollectingInvalidNumberOfArguments, .timeout = 5
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("pgt", {}), Gui::Errors::GuiUpdaterException);
@@ -650,7 +650,7 @@ Test(GUIUpdater, updateRessourceCollectingInvalidNumberOfArguments, .timeout = 5
 Test(GUIUpdater, updatePlayerDeath, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -662,7 +662,7 @@ Test(GUIUpdater, updatePlayerDeath, .timeout = 5)
 Test(GUIUpdater, updatePlayerDeathErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -673,7 +673,7 @@ Test(GUIUpdater, updatePlayerDeathErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerDeathErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -684,7 +684,7 @@ Test(GUIUpdater, updatePlayerDeathErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateEggLaidByPlayer, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -697,7 +697,7 @@ Test(GUIUpdater, updateEggLaidByPlayerServerId, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData.get()->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData.get()->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -709,7 +709,7 @@ Test(GUIUpdater, updateEggLaidByPlayerServerId, .timeout = 5)
 Test(GUIUpdater, updateEggLaidByPlayerErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("enw", {"test", "test", "test", "test"}), Gui::Errors::GuiUpdaterException);
@@ -718,7 +718,7 @@ Test(GUIUpdater, updateEggLaidByPlayerErrorValue, .timeout = 5)
 Test(GUIUpdater, updateEggLaidByPlayerErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("enw", {"-1", "-1", "-1", "-1"}), Gui::Errors::GuiUpdaterException);
@@ -728,7 +728,7 @@ Test(GUIUpdater, updateEggLaidByPlayerInvalidNumberOfArguments, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("enw", {}), Gui::Errors::GuiUpdaterException);
@@ -737,7 +737,7 @@ Test(GUIUpdater, updateEggLaidByPlayerInvalidNumberOfArguments, .timeout = 5)
 Test(GUIUpdater, updatePlayerBorn, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     gameData.get()->addPlayerToTeam("TEAM1", Gui::Player(1, "TEAM1", std::make_pair(1, 1), 1, 1));
@@ -749,7 +749,7 @@ Test(GUIUpdater, updatePlayerBorn, .timeout = 5)
 Test(GUIUpdater, updatePlayerBornErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ebo", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -758,7 +758,7 @@ Test(GUIUpdater, updatePlayerBornErrorValue, .timeout = 5)
 Test(GUIUpdater, updatePlayerBornErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("ebo", {"-1"}), Gui::Errors::GuiUpdaterException);
@@ -767,7 +767,7 @@ Test(GUIUpdater, updatePlayerBornErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateEggDeath, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
     Gui::Egg egg(1, "TEAM1", std::make_pair(1, 1));
@@ -780,7 +780,7 @@ Test(GUIUpdater, updateEggDeath, .timeout = 5)
 Test(GUIUpdater, updateEggDeathErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("edi", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -789,7 +789,7 @@ Test(GUIUpdater, updateEggDeathErrorValue, .timeout = 5)
 Test(GUIUpdater, updateEggDeathErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("edi", {"-1"}), Gui::Errors::GuiUpdaterException);
@@ -798,7 +798,7 @@ Test(GUIUpdater, updateEggDeathErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitRequest, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("sgt", {"5"});
@@ -809,7 +809,7 @@ Test(GUIUpdater, updateTimeUnitRequest, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitRequestErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("sgt", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -818,7 +818,7 @@ Test(GUIUpdater, updateTimeUnitRequestErrorValue, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitRequestErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("sgt", {"-1"}), Gui::Errors::GuiUpdaterException);
@@ -827,7 +827,7 @@ Test(GUIUpdater, updateTimeUnitRequestErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitModification, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
     gameData->addTeam("TEAM1", "not_tested", "not_tested", (Color){0, 0, 0, 0});
 
@@ -838,7 +838,7 @@ Test(GUIUpdater, updateTimeUnitModification, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitModificationErrorValue, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("sst", {"test"}), Gui::Errors::GuiUpdaterException);
@@ -847,7 +847,7 @@ Test(GUIUpdater, updateTimeUnitModificationErrorValue, .timeout = 5)
 Test(GUIUpdater, updateTimeUnitModificationErrorValue2, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert_throw(guiUpdater.update("sst", {"-1"}), Gui::Errors::GuiUpdaterException);
@@ -856,7 +856,7 @@ Test(GUIUpdater, updateTimeUnitModificationErrorValue2, .timeout = 5)
 Test(GUIUpdater, updateEndOfGame, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     cr_assert(!gameData->getIsEndGame());
@@ -870,7 +870,7 @@ Test(GUIUpdater, updateMessageFromServer, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
     gameData.get()->setMapSize(10, 10);
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("smg", {"test"});
@@ -880,7 +880,7 @@ Test(GUIUpdater, updateMessageFromServer, .timeout = 5)
 Test(GUIUpdater, updateUnknownMessage, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("suc", {"test"});
@@ -890,7 +890,7 @@ Test(GUIUpdater, updateUnknownMessage, .timeout = 5)
 Test(GUIUpdater, updateCommandParameter, .timeout = 5)
 {
     std::shared_ptr<Gui::GameData> gameData = std::make_shared<Gui::GameData>();
-    std::shared_ptr<Gui::Network> network = std::make_shared<Gui::Network>(4242, "no_tested");
+    std::shared_ptr<Gui::INetwork> network = std::make_shared<Gui::Network>(4242, "no_tested");
     Gui::GUIUpdater guiUpdater(gameData, network);
 
     guiUpdater.update("sbp", {"test"});


### PR DESCRIPTION
I refactored the `Network` class.
In fact, to test our program correctly, a network interface is compulsory.
This interface will make us able to develop a simple server that just redirect a standard file descriptor as the server, and then just write into this file descriptor.

To do so, i made an `INetwork` interface, and an abstract class `ANetwork` to simplify all the classes that will inherit from.

To see more details, check this issue: #161 