### PR TITLE
feat: display nb total player in team in Game HUD

### DIFF
--- a/gui/src/Hud/HudGame.cpp
+++ b/gui/src/Hud/HudGame.cpp
@@ -34,7 +34,9 @@ void Gui::HudGame::display()
             teamName += "..";
         }
         DrawTextEx(_font, teamName.c_str(), (Vector2){hudTextPos.x, hudTextPos.y + HUD_GAME_TEXT_MARGING * (index + 1)}, 20, 0, WHITE);
-        DrawTextEx(_font, (std::to_string(_gameData->getTeams()[index].getPlayers().size()) + "x").c_str(), (Vector2){hudTextPos.x + 110, hudTextPos.y + HUD_GAME_TEXT_MARGING * (index + 1)}, 20, 0, WHITE);
+        DrawTextEx(_font, (std::to_string(_gameData->getTeams()[index].getPlayers().size()) + "/" +
+            std::to_string(_gameData->getTeams()[index].getPlayers().size() + _gameData->getTeams()[index].getEggs().size())).c_str(),
+            (Vector2){hudTextPos.x + 100, hudTextPos.y + HUD_GAME_TEXT_MARGING * (index + 1)}, 20, 0, WHITE);
 
         DrawTexture(_playerTexture, hudTextPos.x + 130, hudTextPos.y + HUD_GAME_TEXT_MARGING * (index + 1), _gameData.get()->getTeams()[index].getPlayerColor());
     }


### PR DESCRIPTION
I displayed the number player possible in a team in the Game HUD
![image](https://github.com/FppEpitech/Zappy/assets/114564526/db715d8d-80f9-4ed8-bb20-bd7bb7e20897)
