### PR TITLE
fix: FPS color according to the rest of the debug

### DIFF
--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -156,7 +156,8 @@ void Gui::Render::setTimeUnit(size_t timeUnit)
 void Gui::Render::displayDebug()
 {
     if (_isDebug) {
-        DrawFPS(10, 10);
+        int fps = GetFPS();
+        DrawText(("FPS: " + std::to_string(fps)).c_str(), 10, 10, 20, LIME);
         DrawText(("XYZ: " +
             std::to_string(_camera.getCamera()->position.x) + " / " +
             std::to_string(_camera.getCamera()->position.y) + " / " +


### PR DESCRIPTION
I fixed the color of the FPS according to the rest of the debug.
Before, when the fps goes very low, the color changes to orange and then red, now it stays green