### PR TITLE
Feat/display only players vision zappy gui

### DIFF
--- a/gui/include/Event/Event.hpp
+++ b/gui/include/Event/Event.hpp
@@ -71,6 +71,7 @@ class Gui::Event : public Gui::AEvent {
             {KEY_K, [this](){decreaseRenderDistance();}},
             {KEY_F5, [this](){changeActualPlayerPov();}},
             {KEY_FOUR, [this](){changeActualPlayerPov();}},
+            {KEY_V, [this](){setPlayerVision();}},
             {KEY_KP_ADD, [this](){increaseTimeUnit();}},
             {KEY_KP_SUBTRACT, [this](){decreaseTimeUnit();}},
         };
@@ -172,4 +173,10 @@ class Gui::Event : public Gui::AEvent {
          *
          */
         void decreaseTimeUnit();
+
+        /**
+         * @brief Set the player vision.
+         *
+         */
+        void setPlayerVision();
 };

--- a/gui/include/Render/Decoration.hpp
+++ b/gui/include/Render/Decoration.hpp
@@ -46,8 +46,9 @@ class Gui::Decoration {
          * @param mapSize Size of the map.
          * @param renderDistance Distance to render.
          * @param camPos Position of the camera.
+         * @param displayPos Positions to know what to display.
          */
-        void display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos);
+        void display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos, std::vector<Vector2> displayPos);
 
         /**
          * @brief Generate random emplacement for decorations.
@@ -74,4 +75,14 @@ class Gui::Decoration {
          * @param posTile Position of a tile.
          */
         void displayTree(size_t i, size_t j, Vector3 posTile);
+
+        /**
+         * @brief Check if a position is in player vision.
+         *
+         * @param position Position to check.
+         * @param _playerVisionPositions Positions of player vision.
+         * @return true - Position is in player vision.
+         * @return false - Position is not in player vision.
+        */
+        bool isInArrayPlayerVision(std::pair<size_t, size_t> pos, std::vector<Vector2> _playerVisionPositions);
 };

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -203,6 +203,23 @@ class Gui::Render {
         */
         void setTimeUnit(size_t timeUnit);
 
+        /**
+         * @brief Set the Player Vision value.
+         *
+         * @param isPlayerVision New player vision value.
+         * @note True to display player vision
+         * @note False to not display player vision.
+        */
+        void setPlayerVision(bool isPlayerVision);
+
+        /**
+         * @brief Get the Player Vision value.
+         *
+         * @return true - Display player vision.
+         * @return false - Do not display player vision.
+        */
+        bool getPlayerVision() const;
+
     private:
 
         UserCamera                                  _camera;            //!< Camera of the scene.
@@ -221,6 +238,7 @@ class Gui::Render {
         Model                                       _thystameModel;     //!< Model to display thystames.
         Model                                       _deraumereModel;    //!< Model to display deraumeres.
         Texture2D                                   _cursorTexture;     //!< Cursor texture.
+        std::vector<Vector2>                        _playerVisionPositions;   //!< Player vision positions.
 
         /**
          * @brief Load the models to draw.
@@ -368,4 +386,20 @@ class Gui::Render {
          * @return std::pair<std::size_t, std::size_t> - Tile position.
         */
         std::pair<std::size_t, std::size_t> getCameraTile();
+
+        /**
+         * @brief Get the positions of objects in player vision.
+         *
+         * @return size_t - Player id.
+        */
+        std::vector<Vector2> getPositionsInPlayerVision(size_t playerId);
+
+        /**
+         * @brief Check if a position is in player vision.
+         *
+         * @param position Position to check.
+         * @return true - Position is in player vision.
+         * @return false - Position is not in player vision.
+        */
+        bool isInArrayPlayerVision(std::pair<size_t, size_t> pos);
 };

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -207,7 +207,7 @@ class Gui::Render {
          * @brief Set the Player Vision value.
          *
          * @param isPlayerVision New player vision value.
-         * @note True to display player vision
+         * @note True to display player vision.
          * @note False to not display player vision.
         */
         void setPlayerVision(bool isPlayerVision);

--- a/gui/include/Render/Render.hpp
+++ b/gui/include/Render/Render.hpp
@@ -402,4 +402,22 @@ class Gui::Render {
          * @return false - Position is not in player vision.
         */
         bool isInArrayPlayerVision(std::pair<size_t, size_t> pos);
+
+        /**
+         * @brief Get the line of vision.
+         *
+         * @param pos Position to check.
+         * @param sizeOfHalf size of the half of the line of vision.
+         * @param orientation orientation of the vision.
+         */
+        std::vector<Vector2> getLineOfVision(Vector2 pos, size_t sizeOfHalf, size_t orientation);
+
+        /**
+         * @brief Add a position to the vision.
+         *
+         * @param vision Vision to add the position.
+         * @param pos Positions to add.
+         * @return std::vector<Vector2> - Vision with the position added.
+        */
+        std::vector<Vector2> addVisionPosition(std::vector<Vector2> vision, std::vector<Vector2> pos);
 };

--- a/gui/include/Render/UserCamera.hpp
+++ b/gui/include/Render/UserCamera.hpp
@@ -158,10 +158,26 @@ class Gui::UserCamera {
         */
         bool isPlayerPov() const;
 
+        /**
+         * @brief Check if the camera is in player vision.
+         *
+         * @return true - Camera is in player vision.
+         * @return false - Camera is not in player vision.
+         */
+        bool isPlayerVision() const;
+
+        /**
+         * @brief Set the Player Vision object.
+         *
+         * @param isPlayerVision Is player vision.
+         */
+        void setPlayerVision(bool isPlayerVision);
+
     private:
 
         std::shared_ptr<Camera>                 _camera;        //!< Camera raylib instance.
         CameraType                              _type;          //!< Type of camera.
         size_t                                  _playerId;      //!< Player id.
         std::pair<std::size_t, std::size_t>     _tilePos;       //!< Tile position.
+        bool                                    _isPlayerVision; //!< Is player vision.
 };

--- a/gui/src/Event/Event.cpp
+++ b/gui/src/Event/Event.cpp
@@ -192,3 +192,8 @@ void Gui::Event::decreaseTimeUnit()
     if (_gameData.get()->getTimeUnitFromServer() == GameData::TimeUnitState::NONE)
         _gameData.get()->setTimeUnitFromServer(GameData::TimeUnitState::DECREASE);
 }
+
+void Gui::Event::setPlayerVision()
+{
+    _render.get()->setPlayerVision(!_render.get()->getPlayerVision());
+}

--- a/gui/src/Render/Decoration.cpp
+++ b/gui/src/Render/Decoration.cpp
@@ -30,7 +30,7 @@ Map<bool> Gui::Decoration::getGenerationItem(std::size_t ratio)
     return map;
 }
 
-void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos)
+void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_t renderDistance, std::pair<std::size_t, std::size_t> camPos, std::vector<Vector2> displayPos)
 {
     if (mapSize != _mapSize) {
         _mapSize = mapSize;
@@ -39,6 +39,8 @@ void Gui::Decoration::display(std::pair<std::size_t, std::size_t> mapSize, size_
 
     for (int i = 0; i < (int)_mapSize.first; i++) {
         for (int j = 0; j < (int)_mapSize.second; j++) {
+            if (!isInArrayPlayerVision({i, j}, displayPos))
+                continue;
             if (i > (int)(camPos.first - renderDistance) && i < (int)(camPos.first + renderDistance) && j > (int)(camPos.second - renderDistance) && j < (int)(camPos.second + renderDistance)) {
                 Vector3 posTile = {(float)(i * SIZE_TILE), 0.0f, (float)(j * SIZE_TILE)};
                 displayTree(i, j, posTile);
@@ -52,4 +54,15 @@ void Gui::Decoration::displayTree(size_t i, size_t j, Vector3 posTile)
     Vector3 posTreeModel = POS_TREE;
     if (_mapTree[i][j])
         DrawModelEx(_treeModel, (Vector3){posTile.x + posTreeModel.x, posTile.y + posTreeModel.y, posTile.z + posTreeModel.z}, ROTATION_AXIS_TREE, ROTATION_ANGLE_TREE, SCALE_TREE, WHITE);
+}
+
+bool Gui::Decoration::isInArrayPlayerVision(std::pair<size_t, size_t> pos, std::vector<Vector2> _playerVisionPositions)
+{
+    if (_playerVisionPositions.empty())
+        return true;
+    for (auto &position : _playerVisionPositions) {
+        if (position.x == pos.first && position.y == pos.second)
+            return true;
+    }
+    return false;
 }

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -192,6 +192,8 @@ void Gui::Render::displayPlayers()
 
     for (auto &team : _gameData->getTeams()) {
         for (auto &player : team.getPlayers()) {
+            if (_camera.isPlayerPov())
+                camTile = _gameData->getPlayer(_camera.getPlayerId()).getPosition();
             if (_gameData.get()->getMap().size() == 0 || _gameData.get()->getMap()[player.getPosition().first].size() == 0)
                 return;
             if (abs(player.getPosition().first - camTile.first) > (_renderDistance - 1) || abs(player.getPosition().second - camTile.second) > (_renderDistance - 1))
@@ -280,6 +282,8 @@ void Gui::Render::displayMap()
 
     for (auto &line : _gameData->getMap()) {
         for (auto &tile : line) {
+            if (_camera.isPlayerPov())
+                camTile = _gameData->getPlayer(_camera.getPlayerId()).getPosition();
             if (abs(camTile.first - tile.getPosition().first) > (_renderDistance - 1) || abs(camTile.second - tile.getPosition().second) > (_renderDistance - 1))
                 continue;
             if (!isInArrayPlayerVision(tile.getPosition()))

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -580,7 +580,28 @@ std::vector<Vector2> Gui::Render::getPositionsInPlayerVision(size_t playerId)
     Player player = _gameData->getPlayer(playerId);
     std::vector<Vector2> positions = {(Vector2){(float)player.getPosition().first, (float)player.getPosition().second}};
     size_t orientation = player.getOrientation();
-    (void)orientation;
+    Vector2 tmp = {(float)player.getPosition().first, (float)player.getPosition().second};
+
+    for (size_t i = 1; i <= player.getLevel() && i < (_renderDistance + 3) && i <= 3; i++) {
+        switch (orientation) {
+            case 1:
+                tmp.y -= 1;
+                break;
+            case 2:
+                tmp.x += 1;
+                break;
+            case 3:
+                tmp.y += 1;
+                break;
+            case 4:
+                tmp.x -= 1;
+                break;
+            default:
+                std::cout << "Error: Invalid orientation" << std::endl;
+                break;
+        }
+        positions = addVisionPosition(positions, getLineOfVision(tmp, i, orientation));
+    }
     return positions;
 }
 
@@ -593,4 +614,32 @@ bool Gui::Render::isInArrayPlayerVision(std::pair<size_t, size_t> pos)
             return true;
     }
     return false;
+}
+
+std::vector<Vector2> Gui::Render::getLineOfVision(Vector2 pos, size_t sizeOfHalf, size_t direction)
+{
+    std::vector<Vector2> positions;
+    Vector2 tmp1 = pos;
+    Vector2 tmp2 = pos;
+
+    positions.push_back(pos);
+    for (size_t i = 0; i < sizeOfHalf; i++) {
+        if (direction == 1 || direction == 3) {
+            tmp1.x -= 1;
+            tmp2.x += 1;
+        } else if (direction == 2 || direction == 4) {
+            tmp1.y += 1;
+            tmp2.y -= 1;
+        }
+        positions.push_back(tmp1);
+        positions.push_back(tmp2);
+    }
+    return positions;
+}
+
+std::vector<Vector2> Gui::Render::addVisionPosition(std::vector<Vector2> vision, std::vector<Vector2> pos)
+{
+    for (auto &position : pos)
+        vision.push_back(position);
+    return vision;
 }

--- a/gui/src/Render/Render.cpp
+++ b/gui/src/Render/Render.cpp
@@ -601,7 +601,6 @@ std::vector<Vector2> Gui::Render::getPositionsInPlayerVision(size_t playerId)
                 tmp.x -= 1;
                 break;
             default:
-                std::cout << "Error: Invalid orientation" << std::endl;
                 break;
         }
         positions = addVisionPosition(positions, getLineOfVision(tmp, i, orientation));

--- a/gui/src/Render/UserCamera.cpp
+++ b/gui/src/Render/UserCamera.cpp
@@ -97,3 +97,13 @@ bool Gui::UserCamera::isPlayerPov() const
 {
     return _type == FIRST_PERSON || _type == SECOND_PERSON || _type == THIRD_PERSON;
 }
+
+bool Gui::UserCamera::isPlayerVision() const
+{
+    return _isPlayerVision;
+}
+
+void Gui::UserCamera::setPlayerVision(bool isPlayerVision)
+{
+    _isPlayerVision = isPlayerVision;
+}

--- a/tests/gui/tests/Render/TestDecoration.cpp
+++ b/tests/gui/tests/Render/TestDecoration.cpp
@@ -23,8 +23,9 @@ void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis,
 Test(Decoration, getGenerationItem, .timeout = 5)
 {
     Gui::Decoration deco;
+    std::vector<Vector2> pos;
 
-    deco.display(std::make_pair(2,2), 1, std::make_pair(2,2));
+    deco.display(std::make_pair(2,2), 1, std::make_pair(2,2), pos);
     Map<bool> generation = deco.getGenerationItem(1);
 
     cr_assert(!generation[0][0]);


### PR DESCRIPTION
I added the possibility to see only the player's view.
> [!Note]
> Obviously, the vision is based on level, as shown here.

![image](https://github.com/FppEpitech/Zappy/assets/114673563/1ea5d9e8-42f3-4c02-9460-7fddb09e08a0)


Here's the normal view:

![image](https://github.com/FppEpitech/Zappy/assets/114673563/85a8f754-e2d8-4eb5-ae13-0481f34ffa33)


And here's the player's view:


https://github.com/FppEpitech/Zappy/assets/114673563/e530c354-a246-4e1d-85ff-e0e72959638a


> [!Note]
> The player's view is also affected by the render distance if needed.
