### PR TITLE
fix: buffer management in Network GUI

### DIFF
--- a/gui/include/Network/ANetwork.hpp
+++ b/gui/include/Network/ANetwork.hpp
@@ -77,9 +77,9 @@ class Gui::ANetwork : public Gui::INetwork {
         /**
          * @brief Listen the server and return it message.
          *
-         * @return std::string - Message of the server.
+         * @return BufferState - Buffer state.
          */
-        virtual const std::string listenServer() = 0;
+        virtual BufferState listenServer() = 0;
 
         /**
          * @brief Send a message to the Server.
@@ -88,7 +88,17 @@ class Gui::ANetwork : public Gui::INetwork {
          */
         virtual void sendMessageServer(const std::string& message) = 0;
 
+        /**
+         * @brief Get the Buffer object.
+         * Be careful, this method will
+         * delete the current buffer.
+         *
+         * @return std::string - Buffer message.
+         */
+        std::string getBuffer();
+
     protected:
         int             _port;          //!< Port of the server.
         std::string     _hostName;      //!< Host name of the server.
+        std::string     _buffer;        //!< Buffer to receive server message.
 };

--- a/gui/include/Network/INetwork.hpp
+++ b/gui/include/Network/INetwork.hpp
@@ -24,6 +24,12 @@ class Gui::INetwork {
 
     public:
 
+        enum BufferState {
+            NONE,
+            READY,
+            SERVER_ERROR
+        };
+
         /**
          * @brief Destroy the INetwork object.
          *
@@ -69,9 +75,9 @@ class Gui::INetwork {
         /**
          * @brief Listen to the server.
          *
-         * @return std::string Message from the server.
+         * @return BufferState - Buffer state.
          */
-        virtual const std::string listenServer() = 0;
+        virtual BufferState listenServer() = 0;
 
         /**
          * @brief Send a message to the server.
@@ -79,4 +85,13 @@ class Gui::INetwork {
          * @param message Message to send.
          */
         virtual void sendMessageServer(const std::string &message) = 0;
+
+        /**
+         * @brief Get the Buffer object.
+         * Be careful, this method will
+         * delete the current buffer.
+         *
+         * @return std::string - Buffer message.
+         */
+        virtual std::string getBuffer() = 0;
 };

--- a/gui/include/Network/Network.hpp
+++ b/gui/include/Network/Network.hpp
@@ -50,9 +50,9 @@ class Gui::Network : public Gui::ANetwork {
         /**
          * @brief Listen the server and return it message.
          *
-         * @return std::string - Message of the server.
+         * @return BufferState - Buffer state.
          */
-        const std::string listenServer();
+        BufferState listenServer();
 
         /**
          * @brief Send a message to the Server.
@@ -72,9 +72,9 @@ class Gui::Network : public Gui::ANetwork {
         /**
          * @brief Read the server output.
          *
-         * @return const std::string - Server message.
+         * @return BufferState - Buffer state.
          */
-        const std::string readInfoServer();
+        BufferState readInfoServer();
 
         int             _serverFd;      //!< server file descriptor
         fd_set          _writeFd;       //!< file descriptor for write access

--- a/gui/src/Engine/Engine.cpp
+++ b/gui/src/Engine/Engine.cpp
@@ -34,16 +34,17 @@ void Gui::Engine::run()
 
 void Gui::Engine::listenServer()
 {
-    std::string command = _network.get()->listenServer();
+    Gui::INetwork::BufferState bufferState = _network.get()->listenServer();
 
-    if (command == "")
+    if (bufferState == Gui::INetwork::BufferState::NONE)
         return;
-    if (command == SERVER_DOWN_MESSAGE) {
+    if (bufferState == Gui::INetwork::BufferState::SERVER_ERROR) {
         std::cout << STR_RED << SERVER_DOWN_MESSAGE << STR_RESET << std::endl;
         _gameData.get()->setIsEndGame(true);
         return;
     }
     try {
+        std::string command = _network->getBuffer();
         std::vector<std::string> arguments = _parser->parse(command);
         std::istringstream stream(command);
         std::string keyCommand;

--- a/gui/src/Network/ANetwork.cpp
+++ b/gui/src/Network/ANetwork.cpp
@@ -34,3 +34,10 @@ std::string Gui::ANetwork::getHostName() const
 {
     return this->_hostName;
 }
+
+std::string Gui::ANetwork::getBuffer()
+{
+    std::string command = _buffer;
+    _buffer = "";
+    return command;
+}

--- a/gui/src/Network/Network.cpp
+++ b/gui/src/Network/Network.cpp
@@ -47,38 +47,38 @@ void Gui::Network::selectServer()
         throw Errors::NetworkException("Select failed.");
 }
 
-const std::string Gui::Network::listenServer()
+Gui::Network::BufferState Gui::Network::listenServer()
 {
     selectServer();
-    std::string data = readInfoServer();
-    if (!_isConnected && data == "WELCOME") {
+    BufferState bufferSate = readInfoServer();
+    if (!_isConnected && _buffer == "WELCOME" && bufferSate == READY) {
         sendMessageServer("GRAPHIC\n");
         sendMessageServer("sgt\n");
         sendMessageServer("msz\n");
         sendMessageServer("mct\n");
         sendMessageServer("tna\n");
         _isConnected = true;
-        return "";
+        _buffer = "";
+        return Gui::Network::NONE;
     }
-    return data;
+    return bufferSate;
 }
 
-const std::string Gui::Network::readInfoServer()
+Gui::Network::BufferState Gui::Network::readInfoServer()
 {
-    std::string data;
     char buffer;
     int len;
 
     if (!FD_ISSET(_serverFd, &_readFd))
-        return "";
+        return NONE;
     while ((len = read(_serverFd, &buffer, 1)) > 0) {
         if (buffer == '\n')
-            break;
-        data.append(&buffer, 1);
+            return READY;
+        _buffer.append(&buffer, 1);
     }
     if (len == 0)
-        return SERVER_DOWN_MESSAGE;
-    return data;
+        return SERVER_ERROR;
+    return NONE;
 }
 
 void Gui::Network::sendMessageServer(const std::string &message)


### PR DESCRIPTION
I fixed the buffer management of the Gui's Network class.
More details : #240 

> [!NOTE]
> The server command is now taken into account only when received **\n** character.

> [!NOTE]
> The following server's message will worked:
> - "msz 2 2\n"
> - "msz " + "2 2\n"
>
>But this commands are **two** commands:
> - "msz \n" + "2 2\n"