### PR TITLE
Feat/optimize the commands calls zappy gui

### DIFF
--- a/gui/include/GameDatas/Player.hpp
+++ b/gui/include/GameDatas/Player.hpp
@@ -207,6 +207,20 @@ class Gui::Player {
         clock_t getAnimationTimeEllapsed() const;
 
         /**
+         * @brief Set the Last Position Update object.
+         *
+         * @param lastPositionUpdate Last position update.
+         */
+        void setLastPositionUpdate(clock_t lastPositionUpdate);
+
+        /**
+         * @brief Get the Last Position Update object.
+         *
+         * @return clock_t - Last position update.
+         */
+        clock_t getLastPositionUpdate() const;
+
+        /**
          * @brief Inventory of the player.
          *
          */
@@ -224,4 +238,5 @@ class Gui::Player {
         std::string                             _broadcast;             //!< Broadcast message.
         int                                     _currentFrame;          //!< Current frame animation.
         clock_t                                 _animationTimeEllapsed; //!< Time ellapsed during animation.
+        clock_t                                 _lastPositionUpdate;    //!< Last position update.
 };

--- a/gui/src/Engine/Engine.cpp
+++ b/gui/src/Engine/Engine.cpp
@@ -71,7 +71,11 @@ void Gui::Engine::sendMessageUpdate()
     _network.get()->sendMessageServer("sgt\n");
     for (auto &team : _gameData.get()->getTeams()) {
         for (auto &player : team.getPlayers()) {
-            _network.get()->sendMessageServer("ppo " + std::to_string(player.getId()) + "\n");
+            Player::PlayerState state = player.getState();
+            if (state == Player::PlayerState::DEAD || state == Player::PlayerState::INCANTATION)
+                continue;
+            if ((float)(currentTick - player.getLastPositionUpdate()) / CLOCKS_PER_SEC > 50 / _gameData->getServerTick())
+                _network.get()->sendMessageServer("ppo " + std::to_string(player.getId()) + "\n");
         }
     }
     if (_gameData.get()->getTimeUnitFromServer() == GameData::TimeUnitState::INCREASE)

--- a/gui/src/Engine/Engine.cpp
+++ b/gui/src/Engine/Engine.cpp
@@ -74,8 +74,10 @@ void Gui::Engine::sendMessageUpdate()
             Player::PlayerState state = player.getState();
             if (state == Player::PlayerState::DEAD || state == Player::PlayerState::INCANTATION)
                 continue;
-            if ((float)(currentTick - player.getLastPositionUpdate()) / CLOCKS_PER_SEC > 50 / _gameData->getServerTick())
+            if ((float)(currentTick - player.getLastPositionUpdate()) / CLOCKS_PER_SEC > 50 / _gameData->getServerTick()) {
                 _network.get()->sendMessageServer("ppo " + std::to_string(player.getId()) + "\n");
+                player.setLastPositionUpdate(clock());
+            }
         }
     }
     if (_gameData.get()->getTimeUnitFromServer() == GameData::TimeUnitState::INCREASE)

--- a/gui/src/GUIUpdater/GUIUpdater.cpp
+++ b/gui/src/GUIUpdater/GUIUpdater.cpp
@@ -165,6 +165,7 @@ void Gui::GUIUpdater::updatePlayerPosition(const std::vector<std::string> &data)
                     player.setState(Gui::Player::IDLE);
                 player.setPosition(std::make_pair(args[1], args[2]));
                 player.setOrientation(args[3]);
+                player.setLastPositionUpdate(clock());
             }
         }
     }

--- a/gui/src/GameDatas/Player.cpp
+++ b/gui/src/GameDatas/Player.cpp
@@ -13,6 +13,7 @@ Gui::Player::Player(std::size_t id, const std::string &team, std::pair<std::size
 {
     _currentFrame = 0;
     _state = IDLE;
+    setLastPositionUpdate(clock());
 }
 
 void Gui::Player::setPosition(std::pair<std::size_t, std::size_t> position)

--- a/gui/src/GameDatas/Player.cpp
+++ b/gui/src/GameDatas/Player.cpp
@@ -141,3 +141,13 @@ clock_t Gui::Player::getAnimationTimeEllapsed() const
 {
     return _animationTimeEllapsed;
 }
+
+void Gui::Player::setLastPositionUpdate(clock_t lastPositionUpdate)
+{
+    _lastPositionUpdate = lastPositionUpdate;
+}
+
+clock_t Gui::Player::getLastPositionUpdate() const
+{
+    return _lastPositionUpdate;
+}


### PR DESCRIPTION
With the help of @mathieurobert1, i setup the a clock for each player last `ppo` command call.
The `ppo` command is used to update the player's position.
Now, if the last ppo call last from more that 50 ticks, the Gui is sending `ppo` for this player to the server.
This method avoid sending `ppo` to the server for each tick for nothing.
